### PR TITLE
codex-gpt-5/feature/0002-bootstrap-framework-artifacts: add initial framework artifacts

### DIFF
--- a/docs/methodology/naming-system.md
+++ b/docs/methodology/naming-system.md
@@ -1,0 +1,144 @@
+# Mnemix Workflow Naming System
+
+## Purpose
+
+This document defines the teaching vocabulary for `mnemix-workflow`.
+
+The goal is to keep the methodology memorable without making the repository cryptic. Product language and file/folder language should reinforce each other instead of competing.
+
+## Core Terms
+
+### Workflow
+
+`workflow` is the overall system and methodology.
+
+It refers to:
+
+- the planning method
+- the CLI experience
+- the relationship between specs, UX, plans, tasks, decisions, and optional standards-backed artifacts
+
+### Workstream
+
+A `workstream` is one unit of planned work.
+
+In practice, a workstream is usually:
+
+- one feature
+- one meaningful capability
+- one framework initiative
+- one cohesive implementation narrative
+
+Each workstream lives under `workflow/workstreams/`.
+
+### Spec
+
+`spec.md` defines:
+
+- the problem
+- the users
+- the goals
+- the scope
+- the success criteria
+
+This is the intent artifact.
+
+### UX
+
+`ux.md` defines:
+
+- the user or developer experience
+- the key journeys and states
+- the interaction expectations
+- the acceptance scenarios
+
+This is the experience artifact.
+
+### Plan
+
+`plan.md` defines:
+
+- the implementation strategy
+- the standards involved
+- the rollout and sequencing
+- the main technical decisions still to be made
+
+This is the technical blueprint artifact.
+
+### Tasks
+
+`tasks.md` defines:
+
+- the execution slices
+- the order of work
+- the validation checkpoints
+
+This is the execution artifact.
+
+### Decisions
+
+`workflow/decisions/` stores durable decisions.
+
+Use:
+
+- `workflow/workstreams/<id>/decisions/` for workstream-local decisions
+- `workflow/decisions/` for repo-wide framework decisions that constrain future work
+
+## Folder Naming
+
+### Top-Level Folders
+
+- `workflow/`
+  - chosen as the root artifact domain for the methodology
+- `workflow/workstreams/`
+  - chosen because each feature folder is a stream of work inside the overall workflow
+- `workflow/decisions/`
+  - chosen for durable repo-level framework decisions that should be separate from active workstreams
+- `docs/`
+  - chosen for methodology and planning documents that are not themselves active workstreams
+
+### Why `workflow/`
+
+`workflow` is the name of the methodology, and it works best as the root artifact domain rather than the name of each individual unit.
+
+Using `workflow/` as the container while nesting `workstreams/` inside it keeps both levels clear:
+
+- `workflow/` is the overall artifact space
+- `workflow/workstreams/` is where individual streams of work live
+- `workflow/decisions/` is where repo-level durable decisions live
+
+That avoids mixing repo-level decisions directly into the repo root while still keeping the workstream concept explicit.
+
+### Why Not `specs/`
+
+`specs/` is clear, but too narrow for this methodology.
+
+Each workstream contains more than specs:
+
+- UX intent
+- technical plan
+- tasks
+- decisions
+- optional contracts and architecture artifacts
+
+`workstreams/` better reflects the broader unit, and nesting it under `workflow/` keeps that broader unit inside the methodology's artifact root.
+
+## Teaching Summary
+
+The shortest teachable version of the methodology is:
+
+> A workflow is made of workstreams. Each workstream moves from spec to UX to plan to tasks, with decisions recorded when they become durable.
+
+## Initial Repository Convention
+
+```text
+workflow/
+  workstreams/
+    001-bootstrap-mnemix-workflow/
+      spec.md
+      ux.md
+      plan.md
+      tasks.md
+      decisions/
+  decisions/
+```

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,190 @@
+# Product Requirements Document (PRD)
+
+| Field | Value |
+|-------|-------|
+| **Title** | Mnemix Workflow |
+| **Author** | Codex |
+| **Date** | 2026-03-26 |
+| **Status** | Draft |
+| **Version** | 0.1 |
+| **Ticket** | strategy/workflow/mnemix-workflow |
+
+---
+
+## 1. Overview
+
+`mnemix-workflow` is a lightweight, repo-native feature planning framework for human planning with AI-assisted implementation. It provides a versioned, structured path from intent to execution using `spec.md`, `ux.md`, `plan.md`, and `tasks.md` as the core planning artifacts.
+
+This document is the living product document for the project. It replaces the earlier dated plan file and should be updated as the framework, CLI, and methodology evolve.
+
+## 2. Problem Statement
+
+### Current State
+
+AI coding assistants are powerful, but teams often rely on chat history, loose tickets, or ad hoc docs to explain what should be built. That makes implementation quality inconsistent and forces humans and agents to repeatedly reconstruct context. Existing spec-driven frameworks are useful, but they do not cleanly fit the Mnemix ecosystem's combination of repo-native guidance, progressive disclosure, optional memory, and future visual planning.
+
+### Impact
+
+Without a lightweight, teachable workflow layer:
+
+- product intent drifts from implementation details
+- UX expectations are easy to under-specify
+- AI agents must infer too much from incomplete prompts
+- future sessions lose clarity and narrative continuity
+- the Mnemix ecosystem lacks a dedicated layer between project guidance and implementation execution
+
+## 3. Goals & Objectives
+
+| Goal | Success Metric | Target |
+|------|---------------|--------|
+| Create a lightweight planning workflow | Core workflow works with the four primary artifacts | `spec.md`, `ux.md`, `plan.md`, `tasks.md` are sufficient for the common case |
+| Make UX first-class | UX artifact exists and is used in active workstreams | Every user-facing workstream can define `ux.md` with narrative plus Gherkin scenarios |
+| Keep the system repo-native and AI-operable | Workstreams and decisions live in normal versioned files | No required hidden metadata system for the core workflow |
+| Provide a bootstrap path before the CLI exists | Reusable bootstrap tool exists in the repo | A standards-compliant skill can scaffold new workstreams |
+| Preserve ecosystem fit | Integration boundaries stay clear | `mnemix-context` remains canonical for repo rules and `mnemix` memory remains optional |
+
+### Non-Goals
+
+- Build a heavyweight project-management suite
+- Replace `AGENTS.md` or repo-level instructions as the source of project policy
+- Require memory integration for basic workflow usage
+- Force every feature to use every optional standard or artifact type
+- Finalize all future CLI, validation, export, and Studio integration behavior in v0
+
+## 4. User Personas
+
+| Persona | Role | Need | Pain Point |
+|---------|------|------|------------|
+| Maintainer | Framework author / project lead | A teachable methodology and clear repo structure | Existing workflow ideas are easy to discuss but harder to codify consistently |
+| AI Implementation Agent | Primary implementation worker | Clear, versioned intent and execution artifacts | Chat-only instructions are ambiguous and easy to lose |
+| Contributor | Future collaborator | A quick way to understand the project and start work | Framework repos are often heavy on philosophy and light on usable entrypoints |
+
+## 5. Functional Requirements
+
+### FR1: Core Workstream Artifacts
+- **Description**: The framework must define a simple, repo-native core artifact set.
+- **User Story**: As a maintainer or AI agent, I want a predictable workstream structure, so that I can plan and execute work consistently.
+- **Acceptance Criteria**:
+  - Given a workstream, When it is scaffolded, Then it contains `spec.md`, `ux.md`, `plan.md`, `tasks.md`, and `decisions/`
+  - Given the common case, When a feature is planned, Then the four core files are sufficient without requiring extra layers
+- **Priority**: Must Have
+
+### FR2: First-Class UX Artifact
+- **Description**: The framework must define `ux.md` as a first-party artifact for user or developer experience planning.
+- **User Story**: As a planner, I want to define journeys, states, and acceptance scenarios clearly, so that AI implementation remains aligned with intended behavior.
+- **Acceptance Criteria**:
+  - Given a user-facing workstream, When UX is specified, Then `ux.md` can capture narrative behavior and embedded Gherkin scenarios
+  - Given an AI agent, When it reads `ux.md`, Then it can derive user-visible behavior without relying only on the spec or plan
+- **Priority**: Must Have
+
+### FR3: Repo-Native Workstream Domain
+- **Description**: Active planning artifacts must live in a dedicated workflow domain inside the repository.
+- **User Story**: As a contributor, I want the repo shape to explain itself, so that I can distinguish active workstreams from methodology docs and reusable resources.
+- **Acceptance Criteria**:
+  - Given the repo root, When a user browses it, Then `workflow/` contains active work artifacts
+  - Given durable framework decisions, When they are recorded, Then they live under `workflow/decisions/`
+- **Priority**: Must Have
+
+### FR4: Standards-Compliant Bootstrap Skill
+- **Description**: The repo must include a real Agent Skills Open Standard skill for workstream bootstrapping before the dedicated CLI exists.
+- **User Story**: As an AI agent, I want a standards-compliant bootstrap skill, so that I can create new workstreams consistently using the same conventions the framework teaches.
+- **Acceptance Criteria**:
+  - Given the repository, When an agent inspects `resources/skills/mnemix-workflow/`, Then it finds `SKILL.md`, `assets/`, `scripts/`, and `references/`
+  - Given the bootstrap script, When it runs successfully, Then it creates a new numbered workstream folder with the standard artifact set
+- **Priority**: Must Have
+
+### FR5: Numbering And Naming Conventions
+- **Description**: Workstreams must use a documented numeric-prefix convention that scales beyond 999 entries.
+- **User Story**: As a maintainer, I want predictable ordering and naming, so that the repository remains navigable over time.
+- **Acceptance Criteria**:
+  - Given workstream ids from `001` through `999`, When they are created, Then they are zero-padded to 3 digits
+  - Given more than `999` workstreams, When a new one is created, Then numbering continues at `1000+`
+  - Given tooling, When it determines the next id, Then it sorts numerically rather than lexicographically
+- **Priority**: Must Have
+
+## 6. Non-Functional Requirements
+
+| Category | Requirement | Target |
+|----------|-------------|--------|
+| Simplicity | The common-case workflow should stay small | Four core artifacts plus optional `decisions/` |
+| Clarity | File and folder names should be easy to understand | New contributors can navigate the repo without deep onboarding |
+| Tool Neutrality | The framework should not require one editor or vendor environment | Repo artifacts remain normal Markdown and scripts |
+| Interoperability | Use open standards selectively where they help | MADR, OpenAPI, AsyncAPI, JSON Schema, Structurizr DSL are optional by layer |
+| Maintainability | The bootstrap path should be replaceable by the CLI later | Bootstrap skill mirrors the intended future CLI mental model |
+
+## 7. User Experience
+
+### User Flow
+1. A maintainer or AI agent opens the repository and reads the root README.
+2. They understand the methodology, repository shape, and active workstreams.
+3. They inspect the current workstream or scaffold a new one using the bootstrap skill.
+4. They fill in `spec.md`, `ux.md`, `plan.md`, and `tasks.md`.
+5. They implement or refine the work using those artifacts as the shared source of intent.
+
+### Wireframes / Mockups
+
+Not applicable for the initial repository-first experience. The primary experience surface is the repository structure, Markdown artifacts, and the bootstrap skill.
+
+## 8. Technical Considerations
+
+### Dependencies
+- Agent Skills Open Standard skill shape for the bootstrap implementation
+- Python 3 for the temporary scaffold script
+- Future Rust CLI work in the Mnemix ecosystem
+
+### Constraints
+- `mnemix-context` remains the canonical source of repo-level operating guidance
+- `mnemix` memory integration remains optional, not required
+- The framework should not introduce hidden metadata as a dependency for the core flow
+
+### Data Requirements
+- No database requirements for v0
+- Workflows, decisions, and plans are stored as normal versioned repository files
+
+## 9. Release Criteria
+
+- [ ] Root README clearly explains the product and quickstart
+- [ ] `workflow/` contains the active workstream domain and decision area
+- [ ] The bootstrap skill exists under `resources/skills/mnemix-workflow/`
+- [ ] The bootstrap script can scaffold a valid workstream
+- [ ] `001` and `002` workstreams clearly document the initial methodology and bootstrap path
+- [ ] The next implementation-focused workstream is ready to be created
+
+## 10. Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| The framework becomes too heavy | High | Medium | Keep the common case centered on four files and make other layers additive |
+| UX specification becomes too vague or too heavy | Medium | Medium | Keep `ux.md` narrative-first with selective Gherkin scenarios |
+| The bootstrap skill becomes a permanent substitute for the CLI | Medium | Medium | Keep the script intentionally narrow and document it as transitional |
+| Skill scope grows too large | Medium | Medium | Start with one skill, then split only when real complexity appears |
+| Repo structure becomes confusing | Medium | Low | Keep clear boundaries between `docs/`, `resources/`, and `workflow/` |
+
+## 11. Timeline
+
+| Milestone | Target Date | Owner |
+|-----------|------------|-------|
+| Repository bootstrap and methodology docs | Completed in current repo state | Micah / Codex |
+| Bootstrap skill and temporary scaffold script | Completed in current repo state | Micah / Codex |
+| Next workstream for CLI implementation | Next major milestone | Micah / Codex |
+| Dedicated CLI surface | Future phase | Micah / Codex |
+
+## 12. Open Questions
+
+- [ ] When should validation and export helpers split into their own skills, if ever?
+- [ ] How much of the eventual CLI should mirror the bootstrap skill exactly?
+- [ ] What is the first implementation-focused workstream after the bootstrap phase?
+
+## Appendix
+
+### Related Documents
+- [Methodology Naming System](/Users/micah/Projects/mnemix-workspace/mnemix-workflow/docs/methodology/naming-system.md)
+- [Bootstrap Workstream 001](/Users/micah/Projects/mnemix-workspace/mnemix-workflow/workflow/workstreams/001-bootstrap-mnemix-workflow/spec.md)
+- [Workflow Skill Bootstrap Workstream 002](/Users/micah/Projects/mnemix-workspace/mnemix-workflow/workflow/workstreams/002-workflow-skill-bootstrap/spec.md)
+- [Bootstrap Skill](/Users/micah/Projects/mnemix-workspace/mnemix-workflow/resources/skills/mnemix-workflow/SKILL.md)
+
+### Revision History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1 | 2026-03-26 | Codex | Replaced the dated framework plan with a living PRD |

--- a/resources/skills/mnemix-workflow/SKILL.md
+++ b/resources/skills/mnemix-workflow/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: mnemix-workflow
+description: Bootstrap and maintain mnemix-workflow workstreams. Use when creating a new workstream, updating spec/ux/plan/tasks artifacts, or applying the repository's workflow conventions before the dedicated CLI exists.
+---
+
+# Mnemix Workflow
+
+Use this skill when the task is to create or maintain a `mnemix-workflow` workstream in this repository or another repository using the same conventions.
+
+## What This Skill Owns
+
+- the standard workstream artifact set
+- the pre-CLI scaffold script
+- the numbering and naming rules for workstreams
+
+## Default Workflow
+
+1. If a new workstream is needed, run `scripts/new-workstream.py "<name>"`.
+2. Open the generated `spec.md`, `ux.md`, `plan.md`, and `tasks.md`.
+3. Fill in the artifacts for the actual work.
+4. Record workstream-local decisions in `decisions/`.
+5. Promote durable framework decisions to `workflow/decisions/` when needed.
+
+## Bundled Resources
+
+- Templates: `assets/workstream/`
+- Scaffold script: `scripts/new-workstream.py`
+- Conventions reference: `references/workstream-conventions.md`
+
+## When To Read The Reference
+
+Read `references/workstream-conventions.md` when you need:
+
+- the workstream numbering rules
+- the generated folder shape
+- guidance on when to use repo-level vs workstream-level decisions
+
+## Notes
+
+- Use the scaffold script instead of recreating the folder structure by hand unless there is a good reason not to.
+- The numbering rule is `001` through `999`, then `1000+`; treat the numeric prefix as an integer, not a fixed-width string.
+- This skill is a temporary bridge to the future `mnemix workflow new` CLI command.

--- a/resources/skills/mnemix-workflow/assets/workstream/decisions/README.md
+++ b/resources/skills/mnemix-workflow/assets/workstream/decisions/README.md
@@ -1,0 +1,5 @@
+# Workstream Decisions
+
+This folder is for decisions local to `{{WORKSTREAM_TITLE}}`.
+
+Promote decisions to `workflow/decisions/` when they become durable across future workstreams.

--- a/resources/skills/mnemix-workflow/assets/workstream/plan.md
+++ b/resources/skills/mnemix-workflow/assets/workstream/plan.md
@@ -1,0 +1,56 @@
+# Plan: {{WORKSTREAM_TITLE}}
+
+## Summary
+
+[One short paragraph describing the implementation approach.]
+
+## Scope Analysis
+
+### Affected Areas
+
+| Area | Changes Required |
+|------|-----------------|
+| [Area] | [Change] |
+
+### Affected Layers
+
+- [ ] Documentation
+- [ ] Workflow artifacts
+- [ ] Scripts
+- [ ] CLI implementation
+
+## Technical Design
+
+### Proposed Additions
+
+```text
+[Planned files and folders]
+```
+
+### Design Constraints
+
+- [Constraint 1]
+
+## Implementation Phases
+
+### Phase 1
+
+- [Task 1]
+
+### Phase 2
+
+- [Task 2]
+
+## Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| [Risk] | [Impact] | [Likelihood] | [Mitigation] |
+
+## Open Questions
+
+- [Question 1]
+
+## References
+
+- [Related docs]

--- a/resources/skills/mnemix-workflow/assets/workstream/spec.md
+++ b/resources/skills/mnemix-workflow/assets/workstream/spec.md
@@ -1,0 +1,52 @@
+# Feature Spec: {{WORKSTREAM_TITLE}}
+
+## Summary
+
+[One short paragraph describing the feature or initiative.]
+
+## Problem
+
+[What problem does this workstream address?]
+
+## Users
+
+- Primary persona: [who is the main user?]
+- Secondary persona: [optional]
+
+## Goals
+
+- [Goal 1]
+- [Goal 2]
+
+## Non-Goals
+
+- [Non-goal 1]
+
+## User Value
+
+[Why does this matter?]
+
+## Functional Requirements
+
+- [Requirement 1]
+- [Requirement 2]
+
+## Constraints
+
+- [Constraint 1]
+
+## Success Criteria
+
+- [Outcome 1]
+
+## Risks
+
+- [Risk 1]
+
+## Open Questions
+
+- [Question 1]
+
+## References
+
+- [Related docs]

--- a/resources/skills/mnemix-workflow/assets/workstream/tasks.md
+++ b/resources/skills/mnemix-workflow/assets/workstream/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: {{WORKSTREAM_TITLE}}
+
+## Workstream Goal
+
+[State the goal of this workstream.]
+
+## Execution Slices
+
+### Slice 1
+
+- [ ] [Task 1]
+- [ ] [Task 2]
+
+### Slice 2
+
+- [ ] [Task 3]
+
+## Validation Checklist
+
+- [ ] [Validation 1]
+- [ ] [Validation 2]
+
+## Notes
+
+- [Optional note]

--- a/resources/skills/mnemix-workflow/assets/workstream/ux.md
+++ b/resources/skills/mnemix-workflow/assets/workstream/ux.md
@@ -1,0 +1,96 @@
+# UX Spec: {{WORKSTREAM_TITLE}}
+
+## Summary
+
+[Describe the intended experience.]
+
+## Users And Context
+
+- Primary persona: [user]
+- Context of use: [context]
+- Preconditions: [preconditions]
+
+## User Goals
+
+- [Goal 1]
+
+## Experience Principles
+
+- [Principle 1]
+- [Principle 2]
+
+## Primary Journey
+
+1. [Step 1]
+2. [Step 2]
+3. [Step 3]
+
+## Alternate Flows
+
+### Flow: [Name]
+
+- Trigger: [trigger]
+- Path: [path]
+- Expected outcome: [outcome]
+
+## Surfaces
+
+### Surface: [Name]
+
+- Purpose: [purpose]
+- Key information: [content]
+- Available actions: [actions]
+- Navigation expectations: [expectations]
+
+## States
+
+### Loading
+
+- [Behavior]
+
+### Empty
+
+- [Behavior]
+
+### Success
+
+- [Behavior]
+
+### Error
+
+- [Behavior]
+
+## Interaction Details
+
+- [Input behavior]
+- [Feedback]
+- [Keyboard behavior]
+- [Responsive behavior]
+
+## Content And Tone
+
+- [Important labels/messages]
+- [Voice and tone notes]
+
+## Accessibility Requirements
+
+- [Keyboard expectations]
+- [Focus management]
+- [Screen reader expectations]
+
+## Acceptance Scenarios
+
+```gherkin
+Scenario: [Behavioral scenario]
+  Given ...
+  When ...
+  Then ...
+```
+
+## Open Questions
+
+- [Question 1]
+
+## References
+
+- [Related docs]

--- a/resources/skills/mnemix-workflow/references/workstream-conventions.md
+++ b/resources/skills/mnemix-workflow/references/workstream-conventions.md
@@ -1,0 +1,39 @@
+# Workstream Conventions
+
+## Generated Shape
+
+New workstreams should be created under:
+
+```text
+workflow/workstreams/<id>-<slug>/
+  spec.md
+  ux.md
+  plan.md
+  tasks.md
+  decisions/
+    README.md
+```
+
+## Numbering
+
+- Use zero-padded 3-digit IDs from `001` through `999`
+- After `999`, continue with natural numbers starting at `1000`
+- Always determine the next id numerically, not lexicographically
+
+Examples:
+
+- `001-bootstrap-mnemix-workflow`
+- `014-foo`
+- `999-bar`
+- `1000-baz`
+
+## Naming
+
+- Slugs should be lowercase kebab-case
+- Keep the slug descriptive but compact
+- Use the provided name as the title source for template placeholders
+
+## Decisions
+
+- Keep local decisions in `workflow/workstreams/<id>-<slug>/decisions/`
+- Promote durable framework decisions to `workflow/decisions/`

--- a/resources/skills/mnemix-workflow/scripts/new-workstream.py
+++ b/resources/skills/mnemix-workflow/scripts/new-workstream.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Create a new mnemix-workflow workstream from bundled templates."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def slugify(value: str) -> str:
+    value = value.strip().lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    return value.strip("-")
+
+
+def titleize(value: str) -> str:
+    words = re.split(r"[\s_-]+", value.strip())
+    return " ".join(word.capitalize() for word in words if word)
+
+
+def parse_prefix(path: Path) -> int | None:
+    match = re.match(r"^(\d+)-", path.name)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def next_id(workstreams_dir: Path) -> int:
+    existing = []
+    for child in workstreams_dir.iterdir():
+        if not child.is_dir():
+            continue
+        prefix = parse_prefix(child)
+        if prefix is not None:
+            existing.append(prefix)
+    return (max(existing) + 1) if existing else 1
+
+
+def format_id(value: int) -> str:
+    return f"{value:03d}" if value <= 999 else str(value)
+
+
+def copy_tree(src: Path, dst: Path, substitutions: dict[str, str]) -> None:
+    dst.mkdir(parents=True, exist_ok=False)
+    for item in src.rglob("*"):
+        relative = item.relative_to(src)
+        target = dst / relative
+        if item.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+
+        content = item.read_text()
+        for key, replacement in substitutions.items():
+            content = content.replace(key, replacement)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Create a new mnemix-workflow workstream from templates."
+    )
+    parser.add_argument("name", help="Human-readable workstream name")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[3]
+    templates_dir = (
+        repo_root / "resources" / "skills" / "mnemix-workflow" / "assets" / "workstream"
+    )
+    workstreams_dir = repo_root / "workflow" / "workstreams"
+
+    if not templates_dir.is_dir():
+        print(f"Template directory not found: {templates_dir}", file=sys.stderr)
+        return 1
+
+    workstreams_dir.mkdir(parents=True, exist_ok=True)
+
+    slug = slugify(args.name)
+    if not slug:
+        print("Name must contain at least one letter or digit.", file=sys.stderr)
+        return 1
+
+    numeric_id = next_id(workstreams_dir)
+    formatted_id = format_id(numeric_id)
+    title = titleize(args.name)
+    folder_name = f"{formatted_id}-{slug}"
+    destination = workstreams_dir / folder_name
+
+    if destination.exists():
+        print(f"Workstream already exists: {destination}", file=sys.stderr)
+        return 1
+
+    substitutions = {
+        "{{WORKSTREAM_ID}}": formatted_id,
+        "{{WORKSTREAM_SLUG}}": slug,
+        "{{WORKSTREAM_TITLE}}": title,
+    }
+
+    copy_tree(templates_dir, destination, substitutions)
+
+    print(f"Created workstream: {destination.relative_to(repo_root)}")
+    print("Next step: fill in spec.md, ux.md, plan.md, and tasks.md")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflow/decisions/001-workflow-artifact-root.md
+++ b/workflow/decisions/001-workflow-artifact-root.md
@@ -1,0 +1,31 @@
+# ADR 001: Use `workflow/` As The Artifact Root
+
+## Status
+
+Accepted
+
+## Context
+
+`mnemix-workflow` needs a repository structure that distinguishes:
+
+- explanatory documents
+- reusable operational assets
+- active planning artifacts
+- durable framework decisions
+
+Early iterations considered top-level `workstreams/` and `decisions/` folders directly in the repo root, but that made repo-level decisions feel disconnected from the workflow domain itself.
+
+## Decision
+
+Use `workflow/` as the root artifact domain for active planning artifacts.
+
+Inside it:
+
+- `workflow/workstreams/` stores active workstreams
+- `workflow/decisions/` stores repo-level durable decisions
+
+## Consequences
+
+- The repository root stays cleaner
+- Repo-level decisions are clearly part of the workflow system
+- The distinction between the overall methodology and each individual workstream remains explicit

--- a/workflow/decisions/002-bootstrap-with-one-skill.md
+++ b/workflow/decisions/002-bootstrap-with-one-skill.md
@@ -1,0 +1,27 @@
+# ADR 002: Start With One Bootstrap Skill
+
+## Status
+
+Accepted
+
+## Context
+
+Before the dedicated CLI exists, `mnemix-workflow` needs a bootstrap mechanism that agents can use consistently. A design question emerged around whether to start with one broad skill or split immediately into multiple narrower skills.
+
+## Decision
+
+Start with one skill:
+
+- `resources/skills/mnemix-workflow/`
+
+The skill owns:
+
+- workstream templates
+- the temporary scaffold script
+- the core workstream conventions
+
+## Consequences
+
+- Discovery friction stays low for agents and contributors
+- The bootstrap story remains easy to teach
+- Future split points still exist if the skill grows too large, especially around validation and export

--- a/workflow/decisions/003-workstream-numbering.md
+++ b/workflow/decisions/003-workstream-numbering.md
@@ -1,0 +1,24 @@
+# ADR 003: Use 3-Digit Workstream IDs With 1000+ Overflow
+
+## Status
+
+Accepted
+
+## Context
+
+`mnemix-workflow` needs a numbering convention that is friendly in the common case but still scales past long-lived project growth.
+
+## Decision
+
+Use:
+
+- `001` through `999` as zero-padded 3-digit workstream ids
+- `1000+` as the overflow format after `999`
+
+All tooling must sort and increment workstream ids numerically, not lexicographically.
+
+## Consequences
+
+- The default case stays familiar and compact
+- The convention scales without renumbering old workstreams
+- Tooling must parse numeric prefixes rather than assuming a fixed width forever

--- a/workflow/decisions/README.md
+++ b/workflow/decisions/README.md
@@ -1,0 +1,11 @@
+# Decisions
+
+This folder holds durable, repo-level decisions for `mnemix-workflow`.
+
+Use this location when a decision:
+
+- constrains future workstreams
+- defines framework behavior or repository conventions
+- should outlive the original workstream where it was discovered
+
+Workstream-local decisions should stay beside the workstream in `workflow/workstreams/<id>/decisions/` until they need to be promoted here.

--- a/workflow/workstreams/001-bootstrap-mnemix-workflow/decisions/README.md
+++ b/workflow/workstreams/001-bootstrap-mnemix-workflow/decisions/README.md
@@ -1,0 +1,5 @@
+# Workstream Decisions
+
+This folder is for decisions that currently belong only to the bootstrap workstream.
+
+If a decision becomes durable across future workstreams, promote it to the repo-level [workflow decisions](/Users/micah/Projects/mnemix-workspace/mnemix-workflow/workflow/decisions/README.md) folder.

--- a/workflow/workstreams/001-bootstrap-mnemix-workflow/plan.md
+++ b/workflow/workstreams/001-bootstrap-mnemix-workflow/plan.md
@@ -1,0 +1,88 @@
+# Plan: Bootstrap Mnemix Workflow
+
+## Summary
+
+This workstream establishes the initial repository structure and the first set of planning artifacts so the framework can be developed by dogfooding its own method.
+
+## Scope Analysis
+
+### Affected Areas
+
+| Area | Changes Required |
+|------|-----------------|
+| Repository structure | Add root docs and a workflow artifact root containing workstreams and decisions |
+| Methodology docs | Define vocabulary and initial framework narrative |
+| Planning artifacts | Seed the first workstream with spec, UX, plan, and tasks |
+
+### Affected Layers
+
+- [x] Documentation
+- [x] Workflow artifacts
+- [ ] CLI implementation
+- [ ] Standards adapters
+- [ ] Validation engine
+
+## Technical Design
+
+### Repository Structure
+
+```text
+docs/
+  methodology/
+  plans/
+workflow/
+  decisions/
+  workstreams/
+    001-bootstrap-mnemix-workflow/
+```
+
+### Standards Usage
+
+- No standards adapter is required to create the initial repository shape.
+- The bootstrap work should define where repo-level decisions and future standards-backed artifacts will live.
+
+### Integration Strategy
+
+- Keep the repo standalone and lightweight.
+- Preserve compatibility with the larger Mnemix ecosystem vocabulary.
+- Use the first workstream as the source of truth for the next implementation phase.
+
+## Implementation Phases
+
+### Phase 1: Seed The Repository
+
+- Add `README.md`
+- Add methodology docs
+- Add repo-level `workflow/decisions/`
+- Add the first workstream structure under `workflow/workstreams/`
+
+### Phase 2: Refine The Method
+
+- Review whether file naming and folder naming still feel right in practice
+- Identify which foundational decisions deserve repo-level ADRs
+- Prepare the next workstream for CLI bootstrap
+
+### Phase 3: Transition To Implementation
+
+- Create the next workstream focused on CLI and template scaffolding
+- Begin actual Rust implementation planning
+
+## Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| The framework feels too heavy on first contact | High | Medium | Keep the initial repo shape minimal and centered on one active workstream |
+| Naming feels too abstract | Medium | Medium | Keep file names plain and explain vocabulary in the naming-system doc |
+| Repo docs drift from active workstreams | Medium | Low | Treat workstreams as the operational center and keep docs concise |
+
+## Open Questions
+
+- Should the next workstream be `002-cli-bootstrap` or should CLI planning stay inside `001` a bit longer?
+- Which foundational repo decisions should be formalized first?
+
+## References
+
+- `docs/prd.md`
+- `docs/methodology/naming-system.md`
+- `workflow/workstreams/001-bootstrap-mnemix-workflow/spec.md`
+- `workflow/workstreams/001-bootstrap-mnemix-workflow/ux.md`

--- a/workflow/workstreams/001-bootstrap-mnemix-workflow/spec.md
+++ b/workflow/workstreams/001-bootstrap-mnemix-workflow/spec.md
@@ -1,0 +1,66 @@
+# Feature Spec: Bootstrap Mnemix Workflow
+
+## Summary
+
+Bootstrap the `mnemix-workflow` repository by using the workflow on itself, establishing the first repository structure, the first methodology documents, and the first workstream artifacts.
+
+## Problem
+
+`mnemix-workflow` now exists as a repository, but it does not yet contain the artifacts that define how the framework works in practice. Without that, the framework remains an idea rather than a dogfooded methodology.
+
+## Users
+
+- Primary persona: repository maintainer shaping the framework
+- Secondary persona: AI implementation agent using repository artifacts to build the framework
+
+## Goals
+
+- Establish the initial repository structure.
+- Capture the methodology and naming system inside the repository itself.
+- Create the first workstream that plans the framework using its own artifact model.
+- Keep the initial scope lightweight and teachable.
+
+## Non-Goals
+
+- Implement the Rust CLI in this first workstream.
+- Finalize every future standards adapter or validation rule.
+- Produce a full public README or marketing site.
+
+## User Value
+
+The maintainer and future contributors gain a concrete, readable example of how `mnemix-workflow` is supposed to be used, and AI implementation agents gain structured artifacts that can guide the next development steps.
+
+## Functional Requirements
+
+- The repository should include a concise top-level README.
+- The repository should include a methodology naming-system document.
+- The repository should include a high-level workflow plan.
+- The repository should include the first workstream under `workflow/workstreams/` with `spec.md`, `ux.md`, `plan.md`, and `tasks.md`.
+- The repository should distinguish repo-level decisions in `workflow/decisions/` from workstream-level decisions.
+
+## Constraints
+
+- The methodology must remain lightweight in the common case.
+- The naming system must be memorable without becoming obscure.
+- The framework must stay compatible with the wider Mnemix ecosystem strategy.
+
+## Success Criteria
+
+- A new contributor can open the repo and understand the core methodology quickly.
+- The repo demonstrates the first real `workstream` structure.
+- The first workstream is good enough to guide the next implementation phase.
+
+## Risks
+
+- The framework may feel heavier than intended if the initial structure is too large.
+- Naming may become too branded and lose clarity.
+
+## Open Questions
+
+- Which foundational decisions should be promoted immediately to repo-level `workflow/decisions/`?
+- Should the first CLI implementation live in a second workstream or remain in this bootstrap stream?
+
+## References
+
+- `docs/prd.md`
+- `docs/methodology/naming-system.md`

--- a/workflow/workstreams/001-bootstrap-mnemix-workflow/tasks.md
+++ b/workflow/workstreams/001-bootstrap-mnemix-workflow/tasks.md
@@ -1,0 +1,47 @@
+# Tasks: Bootstrap Mnemix Workflow
+
+## Workstream Goal
+
+Create the minimum viable repository structure and planning artifacts needed to start building `mnemix-workflow` by using the workflow on itself.
+
+## Execution Slices
+
+### Slice 1: Establish Core Repository Shape
+
+- [x] Add a root `README.md`
+- [x] Add `docs/methodology/`
+- [x] Add `docs/prd.md` as the living product document
+- [x] Add repo-level `workflow/decisions/`
+- [x] Add `workflow/workstreams/001-bootstrap-mnemix-workflow/`
+
+### Slice 2: Define The Methodology
+
+- [x] Write the one-line project description
+- [x] Define the vocabulary for workflow, workstream, spec, UX, plan, tasks, and decisions
+- [x] Document why `workstreams/` is the unit-of-work folder
+
+### Slice 3: Dogfood The First Workstream
+
+- [x] Create `spec.md`
+- [x] Create `ux.md`
+- [x] Create `plan.md`
+- [x] Create `tasks.md`
+
+### Slice 4: Prepare The Next Workstream
+
+- [x] Decide which repo-level ADRs should be written first
+- [x] Define the scope of the next workstream for CLI bootstrap
+- [x] Decide whether to add initial template files in the next workstream or a later one
+
+## Validation Checklist
+
+- [x] The repository has a clear root entrypoint
+- [x] The methodology vocabulary lives in the repo
+- [x] The first workstream is self-contained
+- [x] `ux.md` includes Gherkin scenarios
+- [x] The next implementation-focused workstream is defined
+
+## Notes
+
+- This workstream intentionally stops short of CLI implementation.
+- The goal is to make the repo legible and actionable before building code.

--- a/workflow/workstreams/001-bootstrap-mnemix-workflow/ux.md
+++ b/workflow/workstreams/001-bootstrap-mnemix-workflow/ux.md
@@ -1,0 +1,139 @@
+# UX Spec: Bootstrap Mnemix Workflow
+
+## Summary
+
+The first user experience of `mnemix-workflow` is not a GUI, but a repository and CLI experience. The experience should feel simple, teachable, and legible to both humans and AI agents.
+
+## Users And Context
+
+- Primary persona: maintainer bootstrapping the framework
+- Secondary persona: contributor opening the repository for the first time
+- Context of use: local repository browsing, Markdown-based planning, early CLI design
+- Preconditions: the user has the repository open and wants to understand or extend the methodology
+
+## User Goals
+
+- Understand the workflow quickly.
+- Find the active workstream easily.
+- Recognize the difference between repo-level guidance and workstream artifacts.
+- See how the methodology is meant to be used in practice.
+
+## Experience Principles
+
+- The repo should teach by example.
+- The default path should feel lightweight, not bureaucratic.
+- Naming should be memorable and still self-explanatory.
+- A contributor should be able to move from overview to active workstream with minimal hunting.
+
+## Primary Journey
+
+1. The user opens the repository.
+2. They read the README and learn the basic methodology.
+3. They open the naming-system document and understand the vocabulary.
+4. They open the first workstream and see the actual artifacts in use.
+5. They can infer the next implementation steps from the workstream plan and tasks.
+
+## Alternate Flows
+
+### Flow: AI implementation handoff
+
+- Trigger: an AI agent is asked to implement the next phase of the framework
+- Path: the agent reads `spec.md`, `ux.md`, `plan.md`, and `tasks.md`
+- Expected outcome: the agent can act without relying on ambiguous chat history
+
+### Flow: New contributor exploring the repo
+
+- Trigger: a contributor opens the repository for the first time
+- Path: they read `README.md`, then `docs/methodology/naming-system.md`, then the active workstream
+- Expected outcome: they understand the methodology and current direction quickly
+
+## Surfaces
+
+### Surface: Repository root
+
+- Purpose: explain what `mnemix-workflow` is
+- Key information: one-line description, repo shape, starting point
+- Available actions: open docs, open active workstream
+- Navigation expectations: clear path from root to workstreams
+
+### Surface: Methodology docs
+
+- Purpose: define naming and teaching vocabulary
+- Key information: workflow, workstream, spec, UX, plan, tasks, decisions
+- Available actions: read, align terminology, make future naming decisions
+- Navigation expectations: documentation should complement, not replace, the active workstream
+
+### Surface: Active workstream folder
+
+- Purpose: show the methodology in use
+- Key information: problem, experience goals, implementation plan, tasks
+- Available actions: refine artifacts, implement next steps, record decisions
+- Navigation expectations: the workstream should be self-contained enough to guide action
+
+## States
+
+### Loading
+
+- Not applicable in a UI sense, but initial repository comprehension should still feel immediate
+
+### Empty
+
+- An empty repo should quickly become understandable once the starter docs and first workstream are added
+
+### Success
+
+- The user understands what the framework is and where to go next
+
+### Error
+
+- If naming or folder structure is confusing, the repo experience has failed and should be simplified
+
+### Permission Denied
+
+- Not applicable for the initial local repository experience
+
+## Interaction Details
+
+- The repo should privilege obvious entrypoints over deep nesting.
+- File names should be self-explanatory.
+- The active workstream should be easy to find from the root.
+- The methodology should be understandable without reading every document.
+
+## Content And Tone
+
+- The language should be clear, confident, and unpretentious.
+- The framework should sound lightweight and practical rather than academic.
+- Naming should support teaching without becoming gimmicky.
+
+## Accessibility Requirements
+
+- Documents should use readable Markdown structure.
+- Heading hierarchy should be clear.
+- The methodology should not rely on visual diagrams alone for comprehension.
+
+## Acceptance Scenarios
+
+```gherkin
+Scenario: New contributor understands the repo shape quickly
+  Given a contributor opens the repository for the first time
+  When they read the README
+  Then they should understand what mnemix-workflow is
+  And they should know that active feature work lives under workflow/workstreams/
+
+Scenario: AI agent can find the active planning artifacts
+  Given an AI agent is asked to continue building the framework
+  When it opens workflow/workstreams/001-bootstrap-mnemix-workflow/
+  Then it should find spec.md, ux.md, plan.md, and tasks.md
+  And it should have enough context to continue implementation planning
+```
+
+## Open Questions
+
+- Should the README eventually include a visual lifecycle diagram, or stay text-first?
+- How much CLI detail should appear in repository docs versus workstream plans?
+
+## References
+
+- `README.md`
+- `docs/methodology/naming-system.md`
+- `workflow/workstreams/001-bootstrap-mnemix-workflow/spec.md`

--- a/workflow/workstreams/002-workflow-skill-bootstrap/decisions/README.md
+++ b/workflow/workstreams/002-workflow-skill-bootstrap/decisions/README.md
@@ -1,0 +1,5 @@
+# Workstream Decisions
+
+This folder is for decisions local to the workflow skill bootstrap workstream.
+
+Promote decisions to `workflow/decisions/` if they become durable across the framework.

--- a/workflow/workstreams/002-workflow-skill-bootstrap/plan.md
+++ b/workflow/workstreams/002-workflow-skill-bootstrap/plan.md
@@ -1,0 +1,129 @@
+# Plan: Workflow Skill Bootstrap
+
+## Summary
+
+This workstream defines the temporary bootstrap path for creating new workstreams before the dedicated CLI exists by packaging the bootstrap mechanism as a real Agent Skills Open Standard skill.
+
+## Scope Analysis
+
+### Affected Areas
+
+| Area | Changes Required |
+|------|-----------------|
+| Skills | Add a standards-compliant `mnemix-workflow` skill |
+| Skill assets | Add reusable workstream templates under `assets/` |
+| Skill scripts | Add a simple scaffold script for new workstreams under `scripts/` |
+| Skill references | Add focused supporting docs under `references/` as needed |
+| Workflow docs | Explain how the interim bootstrap path fits with the future CLI |
+
+### Affected Layers
+
+- [x] Documentation
+- [x] References/templates
+- [x] Simple scripting
+- [ ] CLI implementation
+
+## Technical Design
+
+### Proposed Repository Additions
+
+```text
+resources/
+  skills/
+    mnemix-workflow/
+      SKILL.md
+      assets/
+        workstream/
+          spec.md
+          ux.md
+          plan.md
+          tasks.md
+      scripts/
+        new-workstream.py
+      references/
+        workstream-conventions.md
+workflow/
+  workstreams/
+    002-workflow-skill-bootstrap/
+```
+
+### Script Behavior
+
+- Accept a workstream name
+- Determine the next numeric workstream id
+- Create `workflow/workstreams/<id>-<slug>/`
+- Copy starter templates from the skill's `assets/workstream/` folder into the new folder
+- Print the created path and next suggested action
+
+### Skill Structure Notes
+
+The Agent Skills specification defines a skill as a directory containing `SKILL.md` plus optional `scripts/`, `references/`, and `assets/` directories. The bootstrap artifact should follow that model directly so the repository can dogfood a real open-standard skill rather than a custom pseudo-skill layout.
+
+### One Skill Or Many
+
+The recommended v0 approach is to start with one skill:
+
+- `resources/skills/mnemix-workflow/`
+
+Reasons:
+
+- the framework is still young and the core workflow narrative should stay unified
+- a single skill reduces discovery friction for agents
+- templates, bootstrap scripting, and methodology guidance are tightly related at this stage
+
+Potential future split points, only if the skill grows too large:
+
+- `mnemix-workstream-bootstrap`
+- `mnemix-workflow-validation`
+- `mnemix-workflow-export`
+
+### Design Constraints
+
+- Keep the script simple enough that agents can read it quickly
+- Prefer deterministic behavior over configurability
+- Treat this as a stepping stone toward `mnemix workflow new`
+- Keep the initial skill small enough that one `SKILL.md` remains understandable
+
+## Implementation Phases
+
+### Phase 1: Add Templates
+
+- Created `resources/skills/mnemix-workflow/SKILL.md`
+- Created starter `spec.md`, `ux.md`, `plan.md`, and `tasks.md` templates
+- Stored them under `resources/skills/mnemix-workflow/assets/workstream/`
+- Added focused supporting docs under `resources/skills/mnemix-workflow/references/`
+
+### Phase 2: Add Scaffold Script
+
+- Implemented a simple script that copies the templates into a new numbered workstream
+- Placed it under `resources/skills/mnemix-workflow/scripts/`
+- Ensured output paths follow the naming-system conventions
+
+### Phase 3: Document Agent Usage
+
+- Explained how agents should use the templates and script before the CLI exists
+- Clarified the future migration path to the CLI
+- Explained why the initial implementation uses one skill instead of multiple skills
+
+## Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| The temporary script becomes sticky and delays CLI design | Medium | Medium | Keep the scope intentionally narrow |
+| Templates become too rigid | Medium | Medium | Keep starter text lightweight and revise based on real usage |
+| Script behavior diverges from future CLI behavior | Medium | Medium | Make the script mirror the intended CLI mental model |
+| The skill grows too broad and becomes hard for agents to load effectively | Medium | Medium | Start with one skill, keep `SKILL.md` concise, and split only when real complexity appears |
+
+## Open Questions
+
+- Should numbering be strictly sequential based on existing folders?
+- Should the script validate names or just normalize them?
+- When should validation and export behaviors split into additional skills, if ever?
+
+## References
+
+- `docs/methodology/naming-system.md`
+- `workflow/workstreams/002-workflow-skill-bootstrap/spec.md`
+- `workflow/workstreams/002-workflow-skill-bootstrap/ux.md`
+- `resources/skills/mnemix-workflow/SKILL.md`
+- `https://agentskills.io/specification`

--- a/workflow/workstreams/002-workflow-skill-bootstrap/spec.md
+++ b/workflow/workstreams/002-workflow-skill-bootstrap/spec.md
@@ -1,0 +1,77 @@
+# Feature Spec: Workflow Skill Bootstrap
+
+## Summary
+
+Create the first reusable bootstrap layer for `mnemix-workflow` as a real Agent Skills Open Standard skill, with workstream templates in the skill's `assets/` folder and a simple scaffold script in the skill's `scripts/` folder that agents can use before the dedicated CLI exists.
+
+## Problem
+
+The repository now demonstrates the methodology through one bootstrap workstream, but there is no reusable mechanism for agents or maintainers to start the next workstream consistently. Without a standards-compliant skill, starter templates, and a simple scaffold script, every new workstream risks drifting in structure and quality, and the bootstrap path will not mirror how agents are actually expected to consume the framework.
+
+## Users
+
+- Primary persona: AI implementation agent asked to start a new workstream
+- Secondary persona: maintainer creating or reviewing new workstreams
+
+## Goals
+
+- Define a real Agent Skills Open Standard skill for `mnemix-workflow`
+- Define reusable workstream templates in the skill's `assets/` folder
+- Define a simple script-based scaffolding path in the skill's `scripts/` folder for pre-CLI usage
+- Keep the bootstrap mechanism minimal and easy for agents to follow
+- Use this workstream to clarify the handoff between templates now and CLI later
+- Decide whether `mnemix-workflow` should start with one skill or multiple skills
+
+## Non-Goals
+
+- Build the full Rust CLI
+- Finalize all validation or standards integration behavior
+- Support every possible workstream shape from the first script version
+
+## User Value
+
+Agents and maintainers will be able to create new workstreams quickly and consistently, reducing drift while the full CLI is still under development.
+
+## Functional Requirements
+
+- The repo should define a standards-compliant skill directory with `SKILL.md`
+- The repo should place the skill under `resources/skills/`
+- The repo should place workstream artifact templates under the skill's `assets/` folder
+- The repo should place the bootstrap scaffold script under the skill's `scripts/` folder
+- The repo should use the skill's `references/` folder for supporting guidance and examples as needed
+- The repo should define the expected minimum output of a scaffolded workstream
+- The repo should plan a simple script that creates a new workstream folder with the standard artifact set
+- The workstream should explain how this temporary script fits into the path toward `mnemix workflow new`
+- The workstream should recommend whether to begin with one skill or multiple skills
+
+## Constraints
+
+- The interim script must stay simple enough for agents to run and understand
+- Templates should be plain Markdown and easy to inspect
+- The bootstrap path should not introduce a second hidden metadata system
+- The skill should follow the Agent Skills directory model cleanly rather than inventing a parallel layout
+
+## Success Criteria
+
+- A contributor can understand what reusable templates will exist, where they live, and how agents will consume them
+- An agent can understand the expected behavior of the pre-CLI scaffold script
+- The next implementation step is clear enough to build without further methodology debate
+- The repository has a clear recommendation on starting with one skill or multiple skills
+- The repository contains a real `resources/skills/mnemix-workflow/` implementation that agents can use today
+
+## Risks
+
+- The temporary script may become overly complex and delay the CLI
+- Template structure may harden too early before real usage feedback
+
+## Open Questions
+
+- Should the skill eventually grow validation and export helpers, or should those split into separate skills first?
+
+## References
+
+- `docs/prd.md`
+- `docs/methodology/naming-system.md`
+- `workflow/workstreams/001-bootstrap-mnemix-workflow/spec.md`
+- `README.md`
+- `https://agentskills.io/specification`

--- a/workflow/workstreams/002-workflow-skill-bootstrap/tasks.md
+++ b/workflow/workstreams/002-workflow-skill-bootstrap/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: Workflow Skill Bootstrap
+
+## Workstream Goal
+
+Define and then implement the minimal bootstrap mechanism for creating new workstreams before the dedicated CLI exists, packaged as a real Agent Skills Open Standard skill.
+
+## Execution Slices
+
+### Slice 1: Define Template Set
+
+- [x] Confirm the minimum starter artifact set
+- [x] Decide to start with one `mnemix-workflow` skill or multiple skills
+- [x] Create `resources/skills/mnemix-workflow/SKILL.md`
+- [x] Create `resources/skills/mnemix-workflow/assets/workstream/spec.md`
+- [x] Create `resources/skills/mnemix-workflow/assets/workstream/ux.md`
+- [x] Create `resources/skills/mnemix-workflow/assets/workstream/plan.md`
+- [x] Create `resources/skills/mnemix-workflow/assets/workstream/tasks.md`
+- [x] Create focused supporting files under `resources/skills/mnemix-workflow/references/`
+
+### Slice 2: Define Scaffold Script
+
+- [x] Choose the implementation language for the temporary script
+- [x] Define numbering and slug rules
+- [x] Define generated folder structure
+- [x] Define output and error messages
+- [x] Place the script under `resources/skills/mnemix-workflow/scripts/`
+
+### Slice 3: Implement And Document
+
+- [x] Add `resources/skills/mnemix-workflow/scripts/new-workstream.py`
+- [x] Add usage notes for agents in `SKILL.md`
+- [x] Verify the script creates a valid starter workstream
+
+## Validation Checklist
+
+- [x] Skill directory follows the Agent Skills spec shape
+- [x] Template location is documented
+- [x] Script output path matches `workflow/workstreams/`
+- [x] Generated workstream includes the required starter files
+- [x] The path to the future CLI remains clear
+
+## Notes
+
+- This workstream is intentionally transitional.
+- The goal is to reduce planning friction now without overdesigning the pre-CLI experience.
+- The current recommendation is to start with one skill and split only if real complexity emerges.

--- a/workflow/workstreams/002-workflow-skill-bootstrap/ux.md
+++ b/workflow/workstreams/002-workflow-skill-bootstrap/ux.md
@@ -1,0 +1,135 @@
+# UX Spec: Workflow Skill Bootstrap
+
+## Summary
+
+The experience of starting a new workstream should feel immediate, predictable, and lightweight for both humans and agents. The user should not need to remember file structure details or manually recreate the artifact set, and agents should be able to activate one well-described skill that contains the templates and helper script in the standard locations.
+
+## Users And Context
+
+- Primary persona: AI agent asked to bootstrap a new workstream
+- Secondary persona: maintainer starting a new feature manually
+- Context of use: local repository work before a dedicated CLI exists
+- Preconditions: the repository already contains the naming system and artifact model
+
+## User Goals
+
+- Start a new workstream with minimal ceremony
+- Get the correct folder and file structure automatically
+- Begin filling in meaningful planning artifacts instead of creating boilerplate by hand
+
+## Experience Principles
+
+- Bootstrapping should feel fast
+- The temporary experience should be easy to replace later with the CLI
+- File structure should be obvious after generation
+- The script should be agent-friendly and human-readable
+
+## Primary Journey
+
+1. The user decides a new workstream is needed.
+2. They run a simple scaffold script with a workstream name.
+3. The script creates the new numbered workstream folder and starter files.
+4. The user opens `spec.md`, `ux.md`, `plan.md`, and `tasks.md` and begins planning.
+
+## Alternate Flows
+
+### Flow: Agent uses templates manually
+
+- Trigger: the script is unavailable or the user wants more control
+- Path: the agent reads the template references and creates the files manually
+- Expected outcome: the workstream still conforms to the expected structure
+
+### Flow: Maintainer reviews generated structure
+
+- Trigger: a new workstream has been scaffolded
+- Path: the maintainer inspects the generated folder and starter content
+- Expected outcome: the structure is predictable and low-friction to review
+
+## Surfaces
+
+### Surface: Skill root
+
+- Purpose: provide the standard entrypoint through `SKILL.md`
+- Key information: what the skill does, when to use it, and which bundled resources exist
+- Available actions: read instructions, activate helper resources
+- Navigation expectations: the skill should be understandable without reading the whole repository
+- Location: `resources/skills/mnemix-workflow/`
+
+### Surface: Skill `assets/`
+
+- Purpose: hold reusable starter templates
+- Key information: expected artifact set and starter structure
+- Available actions: inspect, copy, adapt through the scaffold script
+- Navigation expectations: easy for agents to access after loading the skill
+
+### Surface: Skill `references/`
+
+- Purpose: hold focused supporting guidance and examples
+- Key information: naming rules, generated structure, edge-case notes
+- Available actions: read on demand
+- Navigation expectations: progressive disclosure rather than mandatory reading
+
+### Surface: Scaffold script
+
+- Purpose: create a new workstream from the template set
+- Key information: input name, output location, numbering behavior
+- Available actions: generate a new workstream
+- Navigation expectations: obvious how to use without deep documentation
+
+## States
+
+### Success
+
+- A correctly named workstream folder is created with the expected starter files
+
+### Error
+
+- If numbering collides or arguments are invalid, the message should be understandable and fixable
+
+### Empty
+
+- If no workstreams exist yet, the script should still define a sane starting number
+
+## Interaction Details
+
+- Inputs should be simple and positional
+- Output should confirm the created path
+- The script should avoid surprising side effects
+- Generated files should be plain Markdown and immediately editable
+
+## Content And Tone
+
+- Messages should be concise and practical
+- Template content should be clear, not verbose
+
+## Accessibility Requirements
+
+- Script output should be plain text
+- Generated files should use consistent Markdown heading structure
+
+## Acceptance Scenarios
+
+```gherkin
+Scenario: Agent scaffolds a new workstream
+  Given the repository contains a mnemix-workflow skill with reusable workstream templates
+  When the agent runs the scaffold script with a workstream name
+  Then a new numbered folder should be created under workflow/workstreams/
+  And it should contain spec.md, ux.md, plan.md, and tasks.md
+
+Scenario: Maintainer can inspect templates before generation
+  Given the repository contains the workflow skill
+  When the maintainer opens the skill's assets folder
+  Then they should find the starter workstream templates
+  And they should understand the intended generated structure
+```
+
+## Open Questions
+
+- Should one skill own both template scaffolding and future workflow guidance, or should those split later?
+- Should the script also create `decisions/` by default?
+- Should the templates include guidance comments or stay very sparse?
+
+## References
+
+- `https://agentskills.io/specification`
+- `workflow/workstreams/002-workflow-skill-bootstrap/spec.md`


### PR DESCRIPTION
## Summary
- add the initial PRD, methodology docs, and repo-level workflow decisions
- bootstrap the first two workstreams and dogfood the framework on itself
- add the first `mnemix-workflow` skill plus the temporary `new-workstream.py` scaffold script

## Validation
- confirmed all tasks in workstreams 001 and 002 are complete
- verified the scaffold script help output and prior smoke test
