### PR TITLE
chore(release): prepare v0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mnemix-workflow"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/micahcourey/mnemix-workflow"

--- a/python/mnemix_workflow/_version.py
+++ b/python/mnemix_workflow/_version.py
@@ -1,3 +1,3 @@
 """Package version for the Mnemix Workflow Python distribution."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
## Summary
- bump the workspace version to 0.1.1
- bump the Python package version to 0.1.1
- run the Python package release preflight before publishing

## Verification
- ./scripts/check-python-package.sh

## Follow-up
- After this PR merges, run ./scripts/publish-release.sh 0.1.1 from a clean main checkout.