### PR TITLE
chore: sync GitHub mirror metadata and plan Linear support

### DIFF
--- a/.github/workflows/mxw-github-sync.yml
+++ b/.github/workflows/mxw-github-sync.yml
@@ -1,0 +1,33 @@
+name: Mnemix GitHub Sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "workflow/**"
+      - "workflow/github.yml"
+  workflow_dispatch:
+
+jobs:
+  sync:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.0
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Sync changed GitHub issue mirrors
+        run: cargo run --bin mxw -- github sync --changed

--- a/workflow/github.yml
+++ b/workflow/github.yml
@@ -1,0 +1,5 @@
+enabled: true
+repo: micahcourey/mnemix-workflow
+auto_sync:
+  enabled: true
+  mode: changed

--- a/workflow/patches/0001-formatted-markdown-preview-in-mnx.md
+++ b/workflow/patches/0001-formatted-markdown-preview-in-mnx.md
@@ -1,9 +1,16 @@
 ---
 status: completed
 summary: Added basic Markdown-aware formatting to the mnx preview pane.
-updated: 2026-03-29
+updated: 2026-03-31
 prs:
 - 9
+github:
+  issue:
+    id: 4174790159
+    number: 66
+    url: https://github.com/micahcourey/mnemix-workflow/issues/66
+  parent_issue: null
+  sub_issues: {}
 
 ---
 

--- a/workflow/patches/0002-product-focused-readme-and-mnx-ui-quickstart.md
+++ b/workflow/patches/0002-product-focused-readme-and-mnx-ui-quickstart.md
@@ -1,9 +1,16 @@
 ---
 status: completed
 summary: Reworked the README into a more product-focused entrypoint with clearer mnx and quickstart guidance.
-updated: 2026-03-29
+updated: 2026-03-31
 prs:
 - 10
+github:
+  issue:
+    id: 4174790331
+    number: 67
+    url: https://github.com/micahcourey/mnemix-workflow/issues/67
+  parent_issue: null
+  sub_issues: {}
 
 ---
 

--- a/workflow/patches/0003-code-block-styling-in-mnx.md
+++ b/workflow/patches/0003-code-block-styling-in-mnx.md
@@ -1,9 +1,16 @@
 ---
 status: completed
 summary: Styled fenced Markdown code blocks as distinct terminal blocks in mnx.
-updated: 2026-03-29
+updated: 2026-03-31
 prs:
 - 11
+github:
+  issue:
+    id: 4174790381
+    number: 68
+    url: https://github.com/micahcourey/mnemix-workflow/issues/68
+  parent_issue: null
+  sub_issues: {}
 
 ---
 

--- a/workflow/patches/0004-workflow-skill-cli-cleanup.md
+++ b/workflow/patches/0004-workflow-skill-cli-cleanup.md
@@ -1,9 +1,16 @@
 ---
 status: completed
 summary: Updated the workflow skill and docs to be fully CLI-first and removed the old scaffold script.
-updated: 2026-03-29
+updated: 2026-03-31
 prs:
 - 12
+github:
+  issue:
+    id: 4174790439
+    number: 69
+    url: https://github.com/micahcourey/mnemix-workflow/issues/69
+  parent_issue: null
+  sub_issues: {}
 
 ---
 

--- a/workflow/patches/0005-add-pull-request-ci-checks.md
+++ b/workflow/patches/0005-add-pull-request-ci-checks.md
@@ -1,9 +1,17 @@
 ---
 status: completed
 summary: Added a dedicated PR CI workflow for Rust, shell, and Python package checks.
-updated: 2026-03-29
+updated: 2026-03-31
 prs:
-  - 17
+- 17
+github:
+  issue:
+    id: 4174790479
+    number: 70
+    url: https://github.com/micahcourey/mnemix-workflow/issues/70
+  parent_issue: null
+  sub_issues: {}
+
 ---
 
 # Patch: Add Pull Request Ci Checks

--- a/workflow/patches/0006-include-cargo-lock-in-release-prep.md
+++ b/workflow/patches/0006-include-cargo-lock-in-release-prep.md
@@ -1,9 +1,17 @@
 ---
 status: completed
 summary: Updated the release-prep script so release version bumps include Cargo.lock.
-updated: 2026-03-29
+updated: 2026-03-31
 prs:
-  - 16
+- 16
+github:
+  issue:
+    id: 4174790538
+    number: 71
+    url: https://github.com/micahcourey/mnemix-workflow/issues/71
+  parent_issue: null
+  sub_issues: {}
+
 ---
 
 # Patch: Include Cargo Lock In Release Prep

--- a/workflow/patches/0007-add-release-notes-template.md
+++ b/workflow/patches/0007-add-release-notes-template.md
@@ -1,9 +1,17 @@
 ---
 status: completed
 summary: Added a root release-notes file for the current mnemix-workflow release flow.
-updated: 2026-03-29
+updated: 2026-03-31
 prs:
-  - 16
+- 16
+github:
+  issue:
+    id: 4174790600
+    number: 72
+    url: https://github.com/micahcourey/mnemix-workflow/issues/72
+  parent_issue: null
+  sub_issues: {}
+
 ---
 
 # Patch: Add Release Notes Template

--- a/workflow/patches/0008-align-release-checklist-with-script-flow.md
+++ b/workflow/patches/0008-align-release-checklist-with-script-flow.md
@@ -1,8 +1,17 @@
 ---
 status: completed
 summary: Align the maintainer release checklist with the script-based prep and publish flow.
-updated: 2026-03-30
-prs: [19]
+updated: 2026-03-31
+prs:
+- 19
+github:
+  issue:
+    id: 4174790668
+    number: 73
+    url: https://github.com/micahcourey/mnemix-workflow/issues/73
+  parent_issue: null
+  sub_issues: {}
+
 ---
 
 # Patch: Align Release Checklist With Script Flow

--- a/workflow/workstreams/001-bootstrap-mnemix-workflow/STATUS.md
+++ b/workflow/workstreams/001-bootstrap-mnemix-workflow/STATUS.md
@@ -2,7 +2,32 @@
 status: completed
 summary: Repository bootstrap and core methodology artifacts are in place.
 updated: 2026-03-28
-prs: [1]
+prs:
+- 1
+github:
+  issue: null
+  parent_issue:
+    id: 4174785298
+    number: 21
+    url: https://github.com/micahcourey/mnemix-workflow/issues/21
+  sub_issues:
+    plan.md:
+      id: 4174785691
+      number: 24
+      url: https://github.com/micahcourey/mnemix-workflow/issues/24
+    spec.md:
+      id: 4174785365
+      number: 22
+      url: https://github.com/micahcourey/mnemix-workflow/issues/22
+    tasks.md:
+      id: 4174785779
+      number: 25
+      url: https://github.com/micahcourey/mnemix-workflow/issues/25
+    ux.md:
+      id: 4174785456
+      number: 23
+      url: https://github.com/micahcourey/mnemix-workflow/issues/23
+
 ---
 
 # Status

--- a/workflow/workstreams/002-workflow-skill-bootstrap/STATUS.md
+++ b/workflow/workstreams/002-workflow-skill-bootstrap/STATUS.md
@@ -2,7 +2,32 @@
 status: completed
 summary: The bootstrap skill, templates, and temporary scaffold script are implemented.
 updated: 2026-03-28
-prs: [1]
+prs:
+- 1
+github:
+  issue: null
+  parent_issue:
+    id: 4174785888
+    number: 26
+    url: https://github.com/micahcourey/mnemix-workflow/issues/26
+  sub_issues:
+    plan.md:
+      id: 4174786114
+      number: 29
+      url: https://github.com/micahcourey/mnemix-workflow/issues/29
+    spec.md:
+      id: 4174785926
+      number: 27
+      url: https://github.com/micahcourey/mnemix-workflow/issues/27
+    tasks.md:
+      id: 4174786262
+      number: 30
+      url: https://github.com/micahcourey/mnemix-workflow/issues/30
+    ux.md:
+      id: 4174786021
+      number: 28
+      url: https://github.com/micahcourey/mnemix-workflow/issues/28
+
 ---
 
 # Status

--- a/workflow/workstreams/003-cli-bootstrap/STATUS.md
+++ b/workflow/workstreams/003-cli-bootstrap/STATUS.md
@@ -2,7 +2,32 @@
 status: completed
 summary: The first Rust CLI slice shipped with init and new commands.
 updated: 2026-03-28
-prs: [3]
+prs:
+- 3
+github:
+  issue: null
+  parent_issue:
+    id: 4174786361
+    number: 31
+    url: https://github.com/micahcourey/mnemix-workflow/issues/31
+  sub_issues:
+    plan.md:
+      id: 4174786733
+      number: 34
+      url: https://github.com/micahcourey/mnemix-workflow/issues/34
+    spec.md:
+      id: 4174786493
+      number: 32
+      url: https://github.com/micahcourey/mnemix-workflow/issues/32
+    tasks.md:
+      id: 4174786834
+      number: 35
+      url: https://github.com/micahcourey/mnemix-workflow/issues/35
+    ux.md:
+      id: 4174786634
+      number: 33
+      url: https://github.com/micahcourey/mnemix-workflow/issues/33
+
 ---
 
 # Status

--- a/workflow/workstreams/004-status-metadata-and-cli-support/STATUS.md
+++ b/workflow/workstreams/004-status-metadata-and-cli-support/STATUS.md
@@ -2,7 +2,32 @@
 status: completed
 summary: Status metadata workflow, CLI support, and local hook reminders are implemented.
 updated: 2026-03-28
-prs: [4]
+prs:
+- 4
+github:
+  issue: null
+  parent_issue:
+    id: 4174786914
+    number: 36
+    url: https://github.com/micahcourey/mnemix-workflow/issues/36
+  sub_issues:
+    plan.md:
+      id: 4174787214
+      number: 39
+      url: https://github.com/micahcourey/mnemix-workflow/issues/39
+    spec.md:
+      id: 4174786952
+      number: 37
+      url: https://github.com/micahcourey/mnemix-workflow/issues/37
+    tasks.md:
+      id: 4174787440
+      number: 40
+      url: https://github.com/micahcourey/mnemix-workflow/issues/40
+    ux.md:
+      id: 4174787078
+      number: 38
+      url: https://github.com/micahcourey/mnemix-workflow/issues/38
+
 ---
 
 # Status

--- a/workflow/workstreams/005-interactive-tui-mode/STATUS.md
+++ b/workflow/workstreams/005-interactive-tui-mode/STATUS.md
@@ -4,6 +4,29 @@ summary: Implemented the first browse-first interactive TUI for workstreams and 
 updated: 2026-03-28
 prs:
 - 7
+github:
+  issue: null
+  parent_issue:
+    id: 4174787532
+    number: 41
+    url: https://github.com/micahcourey/mnemix-workflow/issues/41
+  sub_issues:
+    plan.md:
+      id: 4174787781
+      number: 44
+      url: https://github.com/micahcourey/mnemix-workflow/issues/44
+    spec.md:
+      id: 4174787589
+      number: 42
+      url: https://github.com/micahcourey/mnemix-workflow/issues/42
+    tasks.md:
+      id: 4174787919
+      number: 45
+      url: https://github.com/micahcourey/mnemix-workflow/issues/45
+    ux.md:
+      id: 4174787680
+      number: 43
+      url: https://github.com/micahcourey/mnemix-workflow/issues/43
 
 ---
 

--- a/workflow/workstreams/006-patch-lane-for-lightweight-tracked-changes/STATUS.md
+++ b/workflow/workstreams/006-patch-lane-for-lightweight-tracked-changes/STATUS.md
@@ -4,6 +4,29 @@ summary: Implemented the lightweight patch lane so every PR can be tracked in ei
 updated: 2026-03-28
 prs:
 - 6
+github:
+  issue: null
+  parent_issue:
+    id: 4174788054
+    number: 46
+    url: https://github.com/micahcourey/mnemix-workflow/issues/46
+  sub_issues:
+    plan.md:
+      id: 4174788439
+      number: 49
+      url: https://github.com/micahcourey/mnemix-workflow/issues/49
+    spec.md:
+      id: 4174788109
+      number: 47
+      url: https://github.com/micahcourey/mnemix-workflow/issues/47
+    tasks.md:
+      id: 4174788510
+      number: 50
+      url: https://github.com/micahcourey/mnemix-workflow/issues/50
+    ux.md:
+      id: 4174788201
+      number: 48
+      url: https://github.com/micahcourey/mnemix-workflow/issues/48
 
 ---
 

--- a/workflow/workstreams/007-contract-standards-support/STATUS.md
+++ b/workflow/workstreams/007-contract-standards-support/STATUS.md
@@ -4,6 +4,29 @@ summary: Added scaffold-and-validate support for OpenAPI, AsyncAPI, and JSON Sch
 updated: 2026-03-29
 prs:
 - 8
+github:
+  issue: null
+  parent_issue:
+    id: 4174788591
+    number: 51
+    url: https://github.com/micahcourey/mnemix-workflow/issues/51
+  sub_issues:
+    plan.md:
+      id: 4174788857
+      number: 54
+      url: https://github.com/micahcourey/mnemix-workflow/issues/54
+    spec.md:
+      id: 4174788639
+      number: 52
+      url: https://github.com/micahcourey/mnemix-workflow/issues/52
+    tasks.md:
+      id: 4174788971
+      number: 55
+      url: https://github.com/micahcourey/mnemix-workflow/issues/55
+    ux.md:
+      id: 4174788715
+      number: 53
+      url: https://github.com/micahcourey/mnemix-workflow/issues/53
 
 ---
 

--- a/workflow/workstreams/008-release-polish-and-pypi-publish-prep/STATUS.md
+++ b/workflow/workstreams/008-release-polish-and-pypi-publish-prep/STATUS.md
@@ -3,7 +3,31 @@ status: completed
 summary: Added the bundled Python package path, release scripts, publish workflow, hook installation, umbrella validation, and release runbook for the first PyPI release.
 updated: 2026-03-29
 prs:
-  - 13
+- 13
+github:
+  issue: null
+  parent_issue:
+    id: 4174789058
+    number: 56
+    url: https://github.com/micahcourey/mnemix-workflow/issues/56
+  sub_issues:
+    plan.md:
+      id: 4174789421
+      number: 59
+      url: https://github.com/micahcourey/mnemix-workflow/issues/59
+    spec.md:
+      id: 4174789097
+      number: 57
+      url: https://github.com/micahcourey/mnemix-workflow/issues/57
+    tasks.md:
+      id: 4174789522
+      number: 60
+      url: https://github.com/micahcourey/mnemix-workflow/issues/60
+    ux.md:
+      id: 4174789340
+      number: 58
+      url: https://github.com/micahcourey/mnemix-workflow/issues/58
+
 ---
 
 # Status

--- a/workflow/workstreams/009-github-issue-support/STATUS.md
+++ b/workflow/workstreams/009-github-issue-support/STATUS.md
@@ -2,7 +2,32 @@
 status: completed
 summary: Added optional repo-canonical GitHub issue mirroring for workstreams and patches, including filtered and changed-only sync.
 updated: 2026-03-30
-prs: [18]
+prs:
+- 18
+github:
+  issue: null
+  parent_issue:
+    id: 4174789662
+    number: 61
+    url: https://github.com/micahcourey/mnemix-workflow/issues/61
+  sub_issues:
+    plan.md:
+      id: 4174789953
+      number: 64
+      url: https://github.com/micahcourey/mnemix-workflow/issues/64
+    spec.md:
+      id: 4174789709
+      number: 62
+      url: https://github.com/micahcourey/mnemix-workflow/issues/62
+    tasks.md:
+      id: 4174790040
+      number: 65
+      url: https://github.com/micahcourey/mnemix-workflow/issues/65
+    ux.md:
+      id: 4174789848
+      number: 63
+      url: https://github.com/micahcourey/mnemix-workflow/issues/63
+
 ---
 
 # Status

--- a/workflow/workstreams/010-linear-issue-support/STATUS.md
+++ b/workflow/workstreams/010-linear-issue-support/STATUS.md
@@ -2,6 +2,7 @@
 status: open
 summary: Planned issue-first Linear support using the official API and keeping Projects out of the first slice.
 updated: 2026-03-31
+prs: [74]
 ---
 
 # Status

--- a/workflow/workstreams/010-linear-issue-support/STATUS.md
+++ b/workflow/workstreams/010-linear-issue-support/STATUS.md
@@ -1,0 +1,10 @@
+---
+status: open
+summary: Planned issue-first Linear support using the official API and keeping Projects out of the first slice.
+updated: 2026-03-31
+---
+
+# Status
+
+This workstream is active. Keep this file current so CLI workflows and future
+Studio views can understand the current state of the work and any linked PRs.

--- a/workflow/workstreams/010-linear-issue-support/decisions/README.md
+++ b/workflow/workstreams/010-linear-issue-support/decisions/README.md
@@ -1,0 +1,5 @@
+# Workstream Decisions
+
+This folder is for decisions local to `Linear Issue Support`.
+
+Promote decisions to `workflow/decisions/` when they become durable across future workstreams.

--- a/workflow/workstreams/010-linear-issue-support/plan.md
+++ b/workflow/workstreams/010-linear-issue-support/plan.md
@@ -1,0 +1,101 @@
+# Plan: Linear Issue Support
+
+## Summary
+
+Implement Linear support as a second tracker provider that follows the same
+repo-canonical philosophy as GitHub support, but use Linear's issue hierarchy
+instead of projects in v1. The first slice should add Linear config, linkage
+metadata, CLI sync commands, and a provider-specific API client built on the
+official GraphQL API.
+
+## Scope Analysis
+
+### Affected Areas
+
+| Area | Changes Required |
+|------|-----------------|
+| CLI commands | Add `mxw linear init` and `mxw linear sync` flows |
+| Provider layer | Add a Linear API client and sync logic alongside the GitHub provider |
+| Workflow artifacts | Store Linear linkage metadata in `STATUS.md` and patch frontmatter |
+| Documentation | Explain the issue-first model, auth and team setup, and repo-canonical rules |
+| Automation | Add optional changed-only auto-sync support later in the same shape as GitHub support |
+
+### Affected Layers
+
+- [ ] Documentation
+- [ ] Workflow artifacts
+- [ ] Scripts
+- [ ] CLI implementation
+
+## Technical Design
+
+### Proposed Additions
+
+```text
+workflow/linear.yml
+src/linear.rs
+src/commands/linear.rs
+src/cli.rs
+src/status.rs
+README.md
+docs/prd.md
+resources/skills/mnemix-workflow/SKILL.md
+resources/skills/mnemix-workflow/references/workstream-conventions.md
+workflow/workstreams/010-linear-issue-support/
+```
+
+### Design Constraints
+
+- Linear issues, not Linear Projects, are the v1 mirror model
+- Team mapping is mandatory because every Linear issue belongs to a team
+- The provider should use Linear's official GraphQL API directly
+- Personal API key support is the easiest first auth path; OAuth can remain a later expansion path
+- The repo remains canonical; Linear descriptions are overwritten on sync
+- The design should leave room for future webhook-based or changed-only automation without making it mandatory in the first slice
+
+## Implementation Slices
+
+### Slice 1
+
+- Define the Linear config shape in `workflow/linear.yml`
+- Define linkage metadata fields for parent issue and child issues
+- Decide the required team mapping model
+- Decide the status-to-Linear-state mapping
+- Decide the first auth mode and document why
+- Document why Projects are intentionally out of scope for v1
+
+### Slice 2
+
+- Implement `mxw linear init`
+- Implement `mxw linear sync <target>` for workstreams and patches
+- Implement `mxw linear sync --all` for backfill
+- Implement filtered sync such as `mxw linear sync --status open`
+- Create or update one parent issue plus child issues for `spec.md`, `ux.md`, `plan.md`, and `tasks.md`
+- Create or update one issue for patches
+- Persist Linear linkage back into repo metadata
+
+### Slice 3
+
+- Implement `mxw linear sync --changed`
+- Add dry-run output for sync operations
+- Add optional automation support in the same shape as GitHub's changed-only sync flow
+- Update README, PRD, skill docs, and conventions docs
+- Add implementation notes about future Projects mode without making it part of v1
+
+## Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Team mapping is underspecified | Sync cannot create valid Linear issues | High | Make team selection explicit in config and docs from the start |
+| Linear issue hierarchy differs from GitHub enough to resist provider reuse | Abstraction becomes messy | Medium | Keep a shared sync shape but allow provider-specific linkage and API logic |
+| OAuth complexity delays delivery | Shared or team installs take longer than expected | Medium | Start with personal API key auth and design room for OAuth later |
+| Projects prove necessary for some teams sooner than expected | V1 feels too narrow for large programs | Medium | Document Projects as an intentional later mode rather than an accidental omission |
+
+## References
+
+- `workflow/workstreams/009-github-issue-support/plan.md`
+- `https://linear.app/developers/graphql`
+- `https://linear.app/developers/oauth-2-0-authentication`
+- `https://linear.app/developers/webhooks`
+- `https://linear.app/docs/parent-and-sub-issues`
+- `https://linear.app/docs/project-overview`

--- a/workflow/workstreams/010-linear-issue-support/spec.md
+++ b/workflow/workstreams/010-linear-issue-support/spec.md
@@ -1,0 +1,91 @@
+# Feature Spec: Linear Issue Support
+
+## Summary
+
+Add optional Linear support so repositories using `mnemix-workflow` can mirror
+workstreams and patches into Linear while keeping repo artifacts as the source
+of truth. The first slice should be issue-first: a workstream mirrors to one
+parent Linear issue plus child issues for `spec.md`, `ux.md`, `plan.md`, and
+`tasks.md`, while a patch mirrors to a single Linear issue.
+
+## Problem
+
+Some teams run execution out of Linear instead of GitHub, but the newly shipped
+external-tracker support in `mnemix-workflow` only covers GitHub Issues today.
+That leaves Linear-heavy teams without the same repo-canonical sync path and
+forces them to either duplicate planning manually or abandon repo-native
+tracking.
+
+## Users
+
+- Primary persona: maintainer or engineering lead who wants repo-native planning with Linear-native execution visibility
+- Secondary persona: AI implementation agent that needs a deterministic way to create and sync Linear mirrors from repo artifacts
+
+## Goals
+
+- Make Linear support optional and opt-in, just like GitHub support
+- Keep the repo canonical for titles, descriptions, statuses, and work structure
+- Use Linear's issue hierarchy as the default mapping for workstreams and patches
+- Design the provider layer so GitHub and Linear can share sync concepts where practical
+
+## Non-Goals
+
+- Use Linear Projects as the default v1 mirror model
+- Support two-way collaborative editing of Linear issue descriptions
+- Mirror every workstream file or local `decisions/` entry as its own Linear artifact
+- Finalize Projects, Initiatives, or deeper Linear roadmap integrations in this first slice
+
+## User Value
+
+Teams that plan in repo-native Markdown but execute inside Linear get the same
+benefit GitHub teams now have: one source of truth in the repo with a mirrored
+operational surface in the tracker their team already uses.
+
+## Functional Requirements
+
+- The CLI should support enabling or initializing Linear sync for a repository
+- The CLI should support syncing one workstream or one patch into Linear
+- The CLI should support backfill with `--all`
+- The CLI should support filtered sync such as `--status open`
+- The CLI should support `--changed` for automation-friendly refreshes of already-linked items
+- A workstream should map to one parent Linear issue plus child issues for `spec.md`, `ux.md`, `plan.md`, and `tasks.md`
+- A patch should map to one Linear issue
+- Repo metadata should store Linear linkage so sync is deterministic and repeatable
+- Repo `status` values should drive Linear issue state transitions on sync
+- The docs should make it explicit that Linear descriptions are system-managed mirrors and may be overwritten from repo artifacts
+- The configuration model should account for required Linear team mapping
+- The first slice should use Linear's API directly rather than depending on a shell-based CLI integration
+
+## Constraints
+
+- The repo remains canonical; Linear is a mirrored execution layer only
+- The v1 model is issue-first; Projects are intentionally out of scope
+- Every mirrored issue must belong to a Linear team, so team mapping is a required configuration concern
+- The implementation should prefer the official Linear GraphQL API rather than inventing a brittle browser or unofficial CLI flow
+- Auto-sync should refresh already-linked items and avoid surprising broad creation behavior
+
+## Success Criteria
+
+- A repository can opt into Linear support without changing the underlying workstream and patch methodology
+- A workstream sync creates one parent Linear issue plus child issues for `spec.md`, `ux.md`, `plan.md`, and `tasks.md`
+- A patch sync creates one Linear issue with repo metadata linkage
+- Re-running sync updates existing Linear items deterministically from repo content
+- The docs clearly explain why Linear issues are the default model and why Projects are deferred
+
+## Risks
+
+- Team mapping may be awkward for repos whose workstreams span multiple Linear teams
+- Linear issue hierarchy semantics may differ enough from GitHub sub-issues that the provider abstraction needs refinement
+- OAuth and webhook choices may add complexity if the project later wants richer shared/team installations
+- Users may still edit Linear issue descriptions manually unless the repo-canonical model is obvious in docs and product behavior
+
+## References
+
+- `workflow/workstreams/009-github-issue-support/spec.md`
+- `workflow/workstreams/009-github-issue-support/plan.md`
+- `https://linear.app/docs/conceptual-model`
+- `https://linear.app/docs/parent-and-sub-issues`
+- `https://linear.app/docs/project-overview`
+- `https://linear.app/developers/graphql`
+- `https://linear.app/developers/oauth-2-0-authentication`
+- `https://linear.app/developers/webhooks`

--- a/workflow/workstreams/010-linear-issue-support/tasks.md
+++ b/workflow/workstreams/010-linear-issue-support/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: Linear Issue Support
+
+## Workstream Goal
+
+Add optional, repo-canonical Linear issue mirroring for workstreams and patches
+using an issue-first model that keeps Projects out of the first slice.
+
+## Execution Slices
+
+### Slice 1
+
+- [x] Research Linear's official issue, sub-issue, project, GraphQL, auth, and webhook docs
+- [x] Decide that v1 will use issues and child issues rather than Projects
+- [ ] Define the Linear config shape in `workflow/linear.yml`
+- [ ] Define repo metadata fields for linked parent issues, child issues, and patch issues
+- [ ] Define the issue body templates for parent issues, child issues, and patches
+- [ ] Decide and document the status-to-Linear-state mapping
+- [ ] Decide and document the required team mapping model
+- [ ] Decide the first auth mode for v1 and document later OAuth expansion
+
+### Slice 2
+
+- [ ] Implement `mxw linear init`
+- [ ] Implement `mxw linear sync <target>` for workstreams and patches
+- [ ] Implement `mxw linear sync --all` for backfill
+- [ ] Implement filtered sync such as `mxw linear sync --status open`
+- [ ] Create or update one parent issue plus child issues for `spec.md`, `ux.md`, `plan.md`, and `tasks.md`
+- [ ] Create or update one mirrored issue for patches
+- [ ] Persist Linear issue linkage back into repo metadata after sync
+
+### Slice 3
+
+- [ ] Implement `mxw linear sync --changed`
+- [ ] Add dry-run or preview output so users can review intended Linear changes
+- [ ] Add optional automation support for changed-only Linear sync
+- [ ] Update README, PRD, skill docs, and conventions docs with the repo-canonical Linear model
+- [ ] Document why Projects are intentionally deferred from the first slice
+
+## Validation Checklist
+
+- [ ] A workstream can be mirrored into one parent Linear issue and four child issues
+- [ ] A patch can be mirrored into one Linear issue
+- [ ] Re-running sync updates existing Linear issues instead of duplicating them
+- [ ] `mxw linear sync --all` can backfill previously-created tracked items including completed items
+- [ ] Filtered sync updates only the requested subset of tracked items
+- [ ] `mxw linear sync --changed` updates already-linked changed items without creating unrelated new mirrors
+- [ ] Documentation clearly states that repo artifacts remain the source of truth
+- [ ] Documentation clearly states that Projects are out of scope for v1
+
+## Notes
+
+- Future work can add a Projects mode if teams need promoted, larger planning containers, but the first slice should stay issue-first.

--- a/workflow/workstreams/010-linear-issue-support/ux.md
+++ b/workflow/workstreams/010-linear-issue-support/ux.md
@@ -1,0 +1,120 @@
+# UX Spec: Linear Issue Support
+
+## Summary
+
+The CLI should make Linear support feel like a natural sibling to GitHub
+support: explicit, repo-canonical, and predictable. Maintainers should be able
+to initialize Linear sync, mirror one tracked item or a filtered slice, and
+trust that reruns update the same Linear issues instead of creating tracker
+drift.
+
+## Users And Context
+
+- Primary persona: maintainer or engineering lead
+- Context of use: a repository that already uses `mnemix-workflow` and wants Linear as its execution surface
+- Preconditions: the repo has tracked workstreams and patches, and the maintainer has valid Linear credentials plus a chosen team mapping
+
+## User Goals
+
+- Mirror repo-tracked work into Linear without copy/pasting descriptions by hand
+- Keep the repo as the planning source of truth even when the team operates day to day in Linear
+- Backfill older tracked work or sync only open work when rolling the integration out
+
+## Experience Principles
+
+- Repo-first and tracker-second
+- Clear sync scope with low surprise
+- Same mental model as GitHub support where possible
+
+## Primary Journey
+
+1. A maintainer enables Linear support with `mxw linear init`.
+2. The CLI writes repo config for workspace/team mapping and chosen auth mode.
+3. The maintainer runs `mxw linear sync 010` for a workstream.
+4. The CLI creates or updates one parent Linear issue plus child issues for `spec.md`, `ux.md`, `plan.md`, and `tasks.md`.
+5. The CLI writes Linear linkage metadata back into the repo artifact.
+6. On later changes, the maintainer re-runs sync manually or uses optional automation built around `mxw linear sync --changed`.
+
+## Alternate Flows
+
+### Flow: Backfill Existing Work
+
+- Trigger: a repo adopts Linear support after already using `mnemix-workflow`
+- Path: `mxw linear sync --all` or `mxw linear sync --status open --all`
+- Expected outcome: older workstreams and patches are mirrored into Linear, with completed items mapped appropriately from repo status
+
+## Surfaces
+
+### Surface: `mxw linear init`
+
+- Purpose: configure repository-level Linear support
+- Key information: workspace slug or team key, auth mode, auto-sync mode, repo-canonical guidance
+- Available actions: initialize config, opt into future auto-sync, verify prerequisites
+- Navigation expectations: short and explicit, similar to `mxw github init`
+
+### Surface: `mxw linear sync`
+
+- Purpose: create or update mirrored Linear issues from repo artifacts
+- Key information: sync scope, affected tracked items, created or updated issue identifiers, and any skipped items
+- Available actions: target sync, backfill sync, filtered sync, changed-only sync, dry-run
+- Navigation expectations: output should clearly separate parent issue updates from child issue updates
+
+## States
+
+### Loading
+
+- Show which tracked item or sync mode is being processed
+
+### Empty
+
+- If no tracked items match the requested scope, explain that nothing matched instead of silently succeeding
+
+### Success
+
+- Report the Linear issue identifiers created or updated and confirm repo linkage metadata was refreshed
+
+### Error
+
+- Show actionable messages for missing auth, missing team mapping, API permission problems, or unsupported targets
+
+## Interaction Details
+
+- Input behavior should mirror GitHub support flags where possible
+- Feedback should make it obvious that Linear issue descriptions are system-managed mirrors
+- Dry-run mode should print intended creates or updates without mutating Linear or repo metadata
+- Errors should distinguish configuration issues from API or auth failures
+
+## Content And Tone
+
+- Important messages should reinforce that the repo remains canonical
+- Wording should avoid implying that users should edit Linear descriptions directly
+
+## Accessibility Requirements
+
+- CLI help and output must remain readable in standard terminal flows
+- Future TUI or Studio Linear views should preserve keyboard-first navigation expectations established elsewhere in the product
+- Text output should avoid relying on color alone to distinguish created, updated, or skipped items
+
+## Acceptance Scenarios
+
+```gherkin
+Scenario: Sync one workstream into Linear
+  Given a repository has enabled Linear support
+  And workstream 010 exists in repo artifacts
+  When the user runs `mxw linear sync 010`
+  Then the CLI should create or update one parent Linear issue
+  And the CLI should create or update child issues for spec, ux, plan, and tasks
+  And the repo should store the resulting Linear linkage metadata
+
+Scenario: Backfill only open tracked work
+  Given a repository has both open and completed tracked items
+  When the user runs `mxw linear sync --status open --all`
+  Then only open tracked items should be mirrored or refreshed
+  And completed tracked items should not be touched by that sync run
+```
+
+## References
+
+- `workflow/workstreams/009-github-issue-support/ux.md`
+- `https://linear.app/docs/parent-and-sub-issues`
+- `https://linear.app/docs/conceptual-model`


### PR DESCRIPTION
## Summary
- commit the repo's current GitHub mirror linkage metadata and generated GitHub sync config/workflow
- add workstream `010` to plan issue-first Linear support using the official API
- keep Projects out of the first Linear slice while preserving the future option

## Details
- persist `github` linkage metadata into tracked workstream `STATUS.md` files and patch frontmatter
- add `workflow/github.yml` and `.github/workflows/mxw-github-sync.yml`
- add `workflow/workstreams/010-linear-issue-support/` with spec, UX, plan, tasks, and status
- `010` is explicitly planned around Linear issues and child issues, not Projects

## Verification
- planning and metadata only
- reviewed representative status/frontmatter diffs and generated GitHub sync files
