### PR TITLE
codex-gpt-5/feature/011-slash-command-integration: add slash-command installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It combines:
 
 - a lightweight spec-driven planning method built around versioned Markdown artifacts
 - a command-oriented CLI for scaffolding and status management
+- repo-local slash-command installation for supported AI assistants
 - an interactive terminal UI for browsing workstreams and patches quickly
 - optional repo-canonical GitHub issue mirroring for teams that want GitHub execution visibility
 - selective support for machine-readable contract standards where they add real value
@@ -45,6 +46,7 @@ history.
 - `STATUS.md` and frontmatter metadata for lightweight machine-readable state
 - `mnx` for fast interactive browsing
 - `mxw` for explicit scaffolding, status, and contract commands
+- `mxw agent ...` for repo-local slash-command installation in supported assistants
 - optional `mxw github ...` commands for mirroring tracked work into GitHub Issues
 
 ## Install
@@ -155,7 +157,48 @@ mxw status list --status completed
 mxw patch status list --status open
 ```
 
-### 4. Install Optional Git Hooks
+### 4. Install Optional Slash Commands
+
+Install repo-local slash commands for supported assistants:
+
+```bash
+mxw agent install
+```
+
+Show the supported assistant integrations:
+
+```bash
+mxw agent tools
+```
+
+Refresh generated command files after an upgrade:
+
+```bash
+mxw agent update
+```
+
+This writes command files under the current repository for the initial supported
+tools:
+
+- `.claude/commands/mxw/`
+- `.cursor/commands/mxw/`
+
+The installed command set is:
+
+- `/mxw:explore`
+- `/mxw:track`
+- `/mxw:implement`
+- `/mxw:close`
+- `/mxw:sync`
+- `/mxw:status`
+
+These commands are a convenience layer over the normal repo-native workflow.
+`mxw` remains the authoritative workflow engine underneath.
+
+For the full command reference and setup notes, see
+[docs/slash-commands.md](docs/slash-commands.md).
+
+### 5. Install Optional Git Hooks
 
 ```bash
 mxw hooks install
@@ -356,10 +399,12 @@ These artifacts live under a workstream's `contracts/` folder when needed.
 README.md
 Cargo.toml
 docs/
+  slash-commands.md
   methodology/
 src/
 tests/
 resources/
+  commands/
   hooks/
   skills/
     mnemix-workflow/
@@ -373,6 +418,10 @@ workflow/
 
 - `docs/`
   - explanatory docs about the method and product direction
+- `docs/slash-commands.md`
+  - setup and command reference for assistant slash-command integrations
+- `resources/commands/`
+  - shared slash-command prompt templates rendered into supported assistants
 - `resources/skills/`
   - reusable agent-facing assets and templates
 - `resources/hooks/`
@@ -391,6 +440,7 @@ workflow/
 Start with:
 
 - [Methodology Naming System](/Users/micah/Projects/mnemix-workspace/mnemix-workflow/docs/methodology/naming-system.md)
+- [Slash Commands](/Users/micah/Projects/mnemix-workspace/mnemix-workflow/docs/slash-commands.md)
 - [Product Requirements Document](/Users/micah/Projects/mnemix-workspace/mnemix-workflow/docs/prd.md)
 - [Release Checklist](/Users/micah/Projects/mnemix-workspace/mnemix-workflow/docs/release-checklist.md)
 - [Bootstrap Workstream 001](/Users/micah/Projects/mnemix-workspace/mnemix-workflow/workflow/workstreams/001-bootstrap-mnemix-workflow/spec.md)
@@ -409,6 +459,7 @@ The current implementation includes:
 - repo initialization and scaffolding via `mxw`
 - workstream and patch tracking
 - status metadata and PR linkage
+- repo-local slash-command installation via `mxw agent install`
 - browse-first TUI access via `mnx`
 - contract scaffolding and validation for `OpenAPI`, `AsyncAPI`, and `JSON Schema`
 - packaged install support for `pip` and `pipx`

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -1,0 +1,133 @@
+# Slash Commands
+
+`mnemix-workflow` can install repo-local slash-command files for supported AI
+assistants so teams can use Mnemix-native workflow commands directly in chat.
+
+The current command set is:
+
+- `/mxw:explore`
+- `/mxw:track`
+- `/mxw:implement`
+- `/mxw:close`
+- `/mxw:sync`
+- `/mxw:status`
+
+These commands are an integration layer, not a second workflow engine. `mxw`
+and the repo's workflow artifacts remain the source of truth.
+
+## Supported Tools
+
+The first shipped slice supports repo-local command installation for:
+
+- Claude Code
+- Cursor
+
+Use:
+
+```bash
+mxw agent tools
+```
+
+to show the supported integrations and the directory each one uses inside the
+current repository.
+
+## Install
+
+Install the slash commands for all supported tools:
+
+```bash
+mxw agent install
+```
+
+Install for a narrower set:
+
+```bash
+mxw agent install --tool claude
+mxw agent install --tool cursor
+mxw agent install --tool claude --tool cursor
+```
+
+The initial supported layout is:
+
+```text
+.claude/commands/mxw/
+  explore.md
+  track.md
+  implement.md
+  close.md
+  sync.md
+  status.md
+
+.cursor/commands/mxw/
+  explore.md
+  track.md
+  implement.md
+  close.md
+  sync.md
+  status.md
+```
+
+## Update
+
+Refresh generated command files after upgrading `mnemix-workflow` or after
+changing the bundled templates:
+
+```bash
+mxw agent update
+```
+
+If an installed command file has been edited manually, `mxw agent install`
+refuses to overwrite it and tells you to use `mxw agent update` instead.
+
+## Command Reference
+
+### `/mxw:explore`
+
+Use this when you want the agent to investigate, reason through the current
+state, and recommend the next workflow action before making changes.
+
+### `/mxw:track`
+
+Use this when new work should become a tracked workstream or patch. The agent
+should choose the right lane and create repo-native workflow artifacts.
+
+### `/mxw:implement`
+
+Use this when tracked work already exists and implementation should proceed from
+those artifacts.
+
+### `/mxw:close`
+
+Use this when tracked work is ready to finish. The command should update Mnemix
+Workflow status to `completed` rather than assuming archive semantics.
+
+### `/mxw:sync`
+
+Use this when tracked work should be synced into the configured issue tracker.
+Today that primarily maps to the GitHub mirror flow behind `mxw github ...`.
+
+### `/mxw:status`
+
+Use this when you want to inspect the status of one workstream, one patch, or a
+filtered set of tracked items.
+
+## How This Relates To The CLI
+
+The slash commands are a chat-native front door for the same workflow model:
+
+- `/mxw:track` maps onto workstream or patch creation
+- `/mxw:status` maps onto `mxw status ...` or `mxw patch status ...`
+- `/mxw:sync` maps onto the tracker integration configured for the repo
+- `/mxw:close` uses the same status model as `mxw status set ... completed`
+
+Use normal `mxw` commands whenever explicit terminal control is more useful than
+chat invocation.
+
+## Notes
+
+- The installed files are repo-local, which keeps the integration explicit and
+  portable with the repository.
+- The generated templates are bundled under `resources/commands/` in the
+  `mnemix-workflow` repository.
+- The command names are intentionally Mnemix-native rather than copied from
+  another workflow framework.

--- a/resources/commands/close.md
+++ b/resources/commands/close.md
@@ -1,0 +1,20 @@
+# /mxw:close
+
+Use this command to mark tracked work finished in the Mnemix Workflow model.
+
+## Expected Behavior
+
+1. Confirm the tracked work is ready to finish.
+2. Run or summarize the expected validation for the work.
+3. Update the relevant workstream or patch status to `completed`.
+4. Refresh summaries, linked PR metadata, or related workflow notes when
+   appropriate.
+5. Suggest `/mxw:sync` if the repository mirrors tracked work into an external
+   issue tracker.
+
+## Workflow Guardrails
+
+- Use Mnemix Workflow status language such as `completed`.
+- Do not assume archive-folder semantics.
+- If meaningful work remains open, explain what is still incomplete instead of
+  closing the tracked item prematurely.

--- a/resources/commands/explore.md
+++ b/resources/commands/explore.md
@@ -1,0 +1,22 @@
+# /mxw:explore
+
+Use this command when you need to think, investigate, or gather context before
+changing tracked work.
+
+## Expected Behavior
+
+1. Inspect the repository, relevant code, tests, and existing workflow artifacts.
+2. If tracked work already exists, read the relevant `spec.md`, `ux.md`,
+   `plan.md`, `tasks.md`, `STATUS.md`, or patch file before suggesting changes.
+3. Summarize what you found, identify risks or unknowns, and recommend the next
+   workflow step.
+4. Prefer analysis and recommendations over code changes unless the user also
+   asked you to implement.
+
+## Workflow Guardrails
+
+- Keep `mxw` and repo artifacts as the source of truth.
+- If no tracked work exists yet and new work should be created, suggest or use
+  `/mxw:track`.
+- If implementation should begin immediately from tracked artifacts, suggest or
+  use `/mxw:implement`.

--- a/resources/commands/implement.md
+++ b/resources/commands/implement.md
@@ -1,0 +1,22 @@
+# /mxw:implement
+
+Use this command to implement from existing workflow artifacts.
+
+## Expected Behavior
+
+1. Read the relevant workstream artifacts or patch content before changing code.
+2. Implement the requested work using the tracked artifacts as the shared source
+   of intent.
+3. Update task state or related workflow metadata when the implementation
+   materially advances the tracked work.
+4. Run the smallest meaningful validation set for the changed behavior.
+5. Summarize what changed, what was validated, and any follow-up risk.
+
+## Workflow Guardrails
+
+- Treat `spec.md`, `ux.md`, `plan.md`, `tasks.md`, and `STATUS.md` as the
+  workflow source of truth.
+- If the tracked artifacts are missing or materially incomplete, stop and use
+  `/mxw:track` or ask for clarification before coding.
+- Prefer finishing the requested implementation end to end, not just partial
+  analysis.

--- a/resources/commands/status.md
+++ b/resources/commands/status.md
@@ -1,0 +1,21 @@
+# /mxw:status
+
+Use this command to inspect or report the status of tracked work.
+
+## Expected Behavior
+
+1. Determine whether the user wants the status of one workstream, one patch, or
+   a broader list.
+2. Use `mxw status ...` for workstreams and `mxw patch status ...` for patches.
+3. Report the current status value, summary, update date, and linked PRs when
+   present.
+4. If the user is unsure which tracked item to inspect, list the relevant open
+   or completed items first.
+
+## Workflow Guardrails
+
+- Keep status reporting grounded in repo metadata, not guesswork.
+- Use the numeric id or full tracked item name when referring to a workstream or
+  patch.
+- If the requested tracked item does not exist, say so clearly and recommend the
+  next best workflow action.

--- a/resources/commands/sync.md
+++ b/resources/commands/sync.md
@@ -1,0 +1,23 @@
+# /mxw:sync
+
+Use this command to sync tracked work into the repository's configured issue
+tracker integration.
+
+## Expected Behavior
+
+1. Inspect the repository configuration and determine which tracker integration
+   is available.
+2. If GitHub issue mirroring is configured, use the `mxw github ...` command
+   surface to sync the requested work.
+3. If no tracker integration is configured, explain that clearly and tell the
+   user what setup step is missing.
+4. Keep the repo as the source of truth and treat external issues as mirrors.
+
+## Workflow Guardrails
+
+- Today GitHub is the primary shipped sync surface. Future tracker providers may
+  be added behind the same command language.
+- Do not hand-edit mirrored issue bodies when `mxw` can sync from repo
+  artifacts.
+- Be explicit about whether you are syncing one tracked item, all tracked work,
+  or a filtered slice.

--- a/resources/commands/track.md
+++ b/resources/commands/track.md
@@ -1,0 +1,23 @@
+# /mxw:track
+
+Use this command to create the right tracked unit for new work.
+
+## Expected Behavior
+
+1. Decide whether the request should become a full workstream or a lightweight
+   patch.
+2. Review existing tracked work first when that context could avoid duplicate or
+   overlapping planning.
+3. Use `mxw new "<name>"` for a workstream or `mxw patch new "<name>"` for a
+   patch.
+4. Fill in the created artifact or artifacts so they are ready for execution,
+   resolving important planning questions with the user when needed.
+5. Keep the resulting planning repo-native and aligned with Mnemix Workflow
+   conventions.
+
+## Workflow Guardrails
+
+- Prefer a workstream for larger multi-artifact work.
+- Prefer a patch for narrow, well-bounded fixes or enhancements.
+- Do not leave placeholder planning sections behind when the answer is already
+  known or can be resolved now.

--- a/resources/skills/mnemix-workflow/SKILL.md
+++ b/resources/skills/mnemix-workflow/SKILL.md
@@ -29,9 +29,10 @@ same conventions.
 8. Keep metadata current with `mxw status`, `mxw patch status`, or the in-TUI status action.
 9. Run `mxw validate` before wrapping up meaningful work so tracked artifacts and optional contracts stay healthy.
 10. If the repository uses GitHub issue mirroring, initialize it with `mxw github init` and sync with `mxw github sync ...` instead of hand-authoring issue bodies.
-11. Offer `mxw hooks install` when the repository would benefit from automatic `updated` refreshes and push-time reminders.
-12. Record workstream-local decisions in `decisions/`.
-13. Promote durable framework decisions to `workflow/decisions/` when needed.
+11. When the repository wants chat-native workflow entrypoints in supported assistants, install them with `mxw agent install`.
+12. Offer `mxw hooks install` when the repository would benefit from automatic `updated` refreshes and push-time reminders.
+13. Record workstream-local decisions in `decisions/`.
+14. Promote durable framework decisions to `workflow/decisions/` when needed.
 
 ## Bundled Resources
 
@@ -61,6 +62,9 @@ Read `references/workstream-conventions.md` when you need:
 - Patches are single files under `workflow/patches/` and carry the same frontmatter metadata directly in the patch file.
 - Every PR should map to either a workstream or a patch.
 - Use `mxw status list` and `mxw patch status list` when you need a non-TUI view of open or completed tracked work.
+- Use `mxw agent install` or `mxw agent update` to install or refresh repo-local slash commands for supported assistants.
+- The bundled slash-command set is `/mxw:explore`, `/mxw:track`, `/mxw:implement`, `/mxw:close`, `/mxw:sync`, and `/mxw:status`.
+- Treat slash commands as a convenience layer over the same repo-native workflow model, not as a separate planning system.
 - Use `mxw validate` to run an umbrella check across tracked metadata and any present contract artifacts.
 - Use `mxw hooks install` to install the bundled `pre-commit` and `pre-push` hook helpers when the repo wants the status nudges.
 - When a repo wants GitHub execution visibility, use `mxw github init --enable-auto-sync`, then `mxw github sync <target>`, `mxw github sync --all`, or `mxw github sync --status open --all`.

--- a/resources/skills/mnemix-workflow/references/workstream-conventions.md
+++ b/resources/skills/mnemix-workflow/references/workstream-conventions.md
@@ -82,8 +82,37 @@ Helpful commands:
 
 - `mxw status list --status open`
 - `mxw patch status list --status completed`
+- `mxw agent install`
+- `mxw agent update`
 - `mxw validate`
 - `mxw hooks install`
+
+## Optional Slash Commands
+
+When a repository wants chat-native workflow entrypoints in supported AI
+assistants, install the repo-local slash commands with:
+
+```bash
+mxw agent install
+```
+
+Refresh them with:
+
+```bash
+mxw agent update
+```
+
+The bundled command set is:
+
+- `/mxw:explore`
+- `/mxw:track`
+- `/mxw:implement`
+- `/mxw:close`
+- `/mxw:sync`
+- `/mxw:status`
+
+These commands are a convenience layer over the normal `mxw` workflow rather
+than a separate planning system.
 
 ## Optional GitHub Issue Mirroring
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,0 +1,202 @@
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, bail};
+
+use crate::cli::AssistantTool;
+
+struct CommandTemplate {
+    name: &'static str,
+    content: &'static str,
+}
+
+const COMMAND_TEMPLATES: &[CommandTemplate] = &[
+    CommandTemplate {
+        name: "explore",
+        content: include_str!("../resources/commands/explore.md"),
+    },
+    CommandTemplate {
+        name: "track",
+        content: include_str!("../resources/commands/track.md"),
+    },
+    CommandTemplate {
+        name: "implement",
+        content: include_str!("../resources/commands/implement.md"),
+    },
+    CommandTemplate {
+        name: "close",
+        content: include_str!("../resources/commands/close.md"),
+    },
+    CommandTemplate {
+        name: "sync",
+        content: include_str!("../resources/commands/sync.md"),
+    },
+    CommandTemplate {
+        name: "status",
+        content: include_str!("../resources/commands/status.md"),
+    },
+];
+
+pub(crate) fn install(
+    repo_root: &Path,
+    selected_tools: &[AssistantTool],
+    overwrite: bool,
+) -> Result<Vec<String>> {
+    let tools = normalized_tools(selected_tools);
+    let planned_writes = planned_writes(repo_root, &tools)?;
+
+    if !overwrite {
+        let conflicts = planned_writes
+            .iter()
+            .filter(|write| write.path.exists() && existing_differs(write))
+            .map(|write| repo_relative(repo_root, &write.path))
+            .collect::<Vec<_>>();
+        if !conflicts.is_empty() {
+            bail!(
+                "Refusing to overwrite existing assistant command files:\n{}\nRun `mxw agent update` to refresh them.",
+                conflicts
+                    .into_iter()
+                    .map(|path| format!("  {path}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
+        }
+    }
+
+    let mut lines = Vec::new();
+    lines.push(if overwrite {
+        "Updated assistant slash commands.".to_owned()
+    } else {
+        "Installed assistant slash commands.".to_owned()
+    });
+
+    for tool in &tools {
+        let commands_dir = tool.commands_dir(repo_root);
+        fs::create_dir_all(&commands_dir)
+            .with_context(|| format!("Failed to create {}", commands_dir.display()))?;
+        lines.push(format!(
+            "{} commands: {}",
+            tool.display_name(),
+            repo_relative(repo_root, &commands_dir)
+        ));
+
+        for template in COMMAND_TEMPLATES {
+            let path = commands_dir.join(format!("{}.md", template.name));
+            let action = if path.exists() {
+                if existing_matches(&path, template.content) {
+                    "Unchanged"
+                } else {
+                    "Updated"
+                }
+            } else {
+                "Created"
+            };
+
+            fs::write(&path, template.content)
+                .with_context(|| format!("Failed to write {}", path.display()))?;
+            lines.push(format!(
+                "  {action}: {}",
+                repo_relative(repo_root, &path)
+            ));
+        }
+    }
+
+    lines.push(format!(
+        "Available slash commands: {}",
+        COMMAND_TEMPLATES
+            .iter()
+            .map(|template| format!("/mxw:{}", template.name))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+    lines.push(
+        "These integrations are repo-local and keep `mxw` as the authoritative workflow engine."
+            .to_owned(),
+    );
+
+    Ok(lines)
+}
+
+pub(crate) fn list_supported_tools(repo_root: &Path) -> Result<Vec<String>> {
+    let tools = normalized_tools(&[]);
+    let mut lines = vec!["Supported assistant integrations:".to_owned()];
+
+    for tool in tools {
+        lines.push(format!(
+            "- {} (`{}`): {}",
+            tool.display_name(),
+            tool.as_str(),
+            repo_relative(repo_root, &tool.commands_dir(repo_root))
+        ));
+    }
+
+    lines.push(
+        "Each tool receives the same namespaced command set: /mxw:explore, /mxw:track, /mxw:implement, /mxw:close, /mxw:sync, /mxw:status."
+            .to_owned(),
+    );
+
+    Ok(lines)
+}
+
+struct PlannedWrite {
+    path: PathBuf,
+    content: &'static str,
+}
+
+fn planned_writes(repo_root: &Path, tools: &[AssistantTool]) -> Result<Vec<PlannedWrite>> {
+    let mut writes = Vec::new();
+    for tool in tools {
+        let commands_dir = tool.commands_dir(repo_root);
+        for template in COMMAND_TEMPLATES {
+            writes.push(PlannedWrite {
+                path: commands_dir.join(format!("{}.md", template.name)),
+                content: template.content,
+            });
+        }
+    }
+
+    Ok(writes)
+}
+
+fn normalized_tools(selected_tools: &[AssistantTool]) -> Vec<AssistantTool> {
+    let tools = if selected_tools.is_empty() {
+        vec![AssistantTool::Claude, AssistantTool::Cursor]
+    } else {
+        selected_tools.to_vec()
+    };
+
+    let mut seen = BTreeSet::new();
+    let mut deduped = Vec::new();
+    for tool in tools {
+        if seen.insert(tool.as_str()) {
+            deduped.push(tool);
+        }
+    }
+    deduped
+}
+
+fn existing_matches(path: &Path, content: &str) -> bool {
+    fs::read_to_string(path).is_ok_and(|existing| existing == content)
+}
+
+fn existing_differs(write: &PlannedWrite) -> bool {
+    !existing_matches(&write.path, write.content)
+}
+
+fn repo_relative(repo_root: &Path, path: &Path) -> String {
+    path.strip_prefix(repo_root)
+        .map(|value| value.display().to_string())
+        .unwrap_or_else(|_| path.display().to_string())
+}
+
+impl AssistantTool {
+    fn commands_dir(self, repo_root: &Path) -> PathBuf {
+        match self {
+            Self::Claude => repo_root.join(".claude").join("commands").join("mxw"),
+            Self::Cursor => repo_root.join(".cursor").join("commands").join("mxw"),
+        }
+    }
+}

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -97,10 +97,7 @@ pub(crate) fn install(
 
             fs::write(&path, template.content)
                 .with_context(|| format!("Failed to write {}", path.display()))?;
-            lines.push(format!(
-                "  {action}: {}",
-                repo_relative(repo_root, &path)
-            ));
+            lines.push(format!("  {action}: {}", repo_relative(repo_root, &path)));
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 const AFTER_HELP: &str = "\
 Install:
@@ -9,6 +9,7 @@ Common commands:
   mxw init
   mxw new \"feature name\"
   mxw patch new \"small fix\"
+  mxw agent install
   mxw validate
   mxw hooks install
   mnx
@@ -30,6 +31,8 @@ pub(crate) struct Cli {
 pub(crate) enum Command {
     /// Initialize the minimum workflow structure in the current repository
     Init,
+    /// Install or refresh assistant slash-command integrations
+    Agent(AgentArgs),
     /// Create a new workstream in an initialized repository
     New(NewArgs),
     /// Scaffold or validate OpenAPI contracts
@@ -50,6 +53,51 @@ pub(crate) enum Command {
     Github(GithubArgs),
     /// Run umbrella validation across tracked workflow artifacts
     Validate(ValidateArgs),
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct AgentArgs {
+    #[command(subcommand)]
+    pub(crate) action: AgentAction,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum AgentAction {
+    /// Install assistant slash-command files into the current repository
+    Install(AgentInstallArgs),
+    /// Refresh assistant slash-command files in the current repository
+    Update(AgentInstallArgs),
+    /// List supported assistant integrations
+    Tools,
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct AgentInstallArgs {
+    /// Assistant integration to configure; repeat to select multiple tools
+    #[arg(long = "tool", value_enum)]
+    pub(crate) tools: Vec<AssistantTool>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub(crate) enum AssistantTool {
+    Claude,
+    Cursor,
+}
+
+impl AssistantTool {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Cursor => "cursor",
+        }
+    }
+
+    pub(crate) fn display_name(self) -> &'static str {
+        match self {
+            Self::Claude => "Claude Code",
+            Self::Cursor => "Cursor",
+        }
+    }
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -1,0 +1,19 @@
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::{
+    agent,
+    cli::{AgentAction, AgentArgs},
+    scaffold::find_repo_root,
+};
+
+pub(crate) fn run(cwd: &Path, _program: &str, args: AgentArgs) -> Result<Vec<String>> {
+    let repo_root = find_repo_root(cwd)?;
+
+    match args.action {
+        AgentAction::Install(args) => agent::install(&repo_root, &args.tools, false),
+        AgentAction::Update(args) => agent::install(&repo_root, &args.tools, true),
+        AgentAction::Tools => agent::list_supported_tools(&repo_root),
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 
 use crate::cli::Command;
 
+mod agent;
 mod asyncapi;
 mod github;
 mod hooks;
@@ -19,6 +20,7 @@ mod validate;
 pub(crate) fn execute(command: Command, program: &str, cwd: &Path) -> Result<Vec<String>> {
     match command {
         Command::Init => init::run(cwd, program),
+        Command::Agent(args) => agent::run(cwd, program, args),
         Command::New(args) => new::run(cwd, program, &args.name),
         Command::Openapi(args) => openapi::run(cwd, program, args),
         Command::Asyncapi(args) => asyncapi::run(cwd, program, args),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! Shared CLI runtime for Mnemix Workflow.
 
+mod agent;
 mod cli;
 mod commands;
 mod contracts;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -238,6 +238,7 @@ fn help_lists_ui_command() {
         .arg("--help")
         .assert()
         .success()
+        .stdout(contains("agent"))
         .stdout(contains("ui"))
         .stdout(contains("github"))
         .stdout(contains("hooks"))
@@ -256,6 +257,100 @@ fn mnx_help_describes_the_tui_shortcut() {
         .success()
         .stdout(contains("interactive Mnemix Workflow TUI"))
         .stdout(contains("Usage:\n  mnx"));
+}
+
+#[test]
+fn agent_tools_lists_supported_integrations() {
+    let temp_dir = init_git_repo();
+
+    Command::cargo_bin("mxw")
+        .expect("binary")
+        .args(["agent", "tools"])
+        .current_dir(temp_dir.path())
+        .assert()
+        .success()
+        .stdout(contains("Claude Code (`claude`): .claude/commands/mxw"))
+        .stdout(contains("Cursor (`cursor`): .cursor/commands/mxw"))
+        .stdout(contains("/mxw:track"));
+}
+
+#[test]
+fn agent_install_writes_repo_local_slash_commands() {
+    let temp_dir = init_git_repo();
+
+    Command::cargo_bin("mxw")
+        .expect("binary")
+        .args(["agent", "install", "--tool", "claude", "--tool", "cursor"])
+        .current_dir(temp_dir.path())
+        .assert()
+        .success()
+        .stdout(contains(".claude/commands/mxw/explore.md"))
+        .stdout(contains(".cursor/commands/mxw/status.md"));
+
+    let claude_track = temp_dir.path().join(".claude/commands/mxw/track.md");
+    let cursor_status = temp_dir.path().join(".cursor/commands/mxw/status.md");
+    assert!(claude_track.is_file());
+    assert!(cursor_status.is_file());
+
+    let track = fs::read_to_string(claude_track).expect("read claude track");
+    assert!(track.contains("# /mxw:track"));
+    assert!(track.contains("mxw patch new"));
+
+    let status = fs::read_to_string(cursor_status).expect("read cursor status");
+    assert!(status.contains("# /mxw:status"));
+    assert!(status.contains("mxw patch status"));
+}
+
+#[test]
+fn agent_install_refuses_to_overwrite_changed_command_files_without_update() {
+    let temp_dir = init_git_repo();
+
+    Command::cargo_bin("mxw")
+        .expect("binary")
+        .args(["agent", "install", "--tool", "claude"])
+        .current_dir(temp_dir.path())
+        .assert()
+        .success();
+
+    let path = temp_dir.path().join(".claude/commands/mxw/explore.md");
+    fs::write(&path, "custom command").expect("overwrite command");
+
+    Command::cargo_bin("mxw")
+        .expect("binary")
+        .args(["agent", "install", "--tool", "claude"])
+        .current_dir(temp_dir.path())
+        .assert()
+        .failure()
+        .stderr(contains("Refusing to overwrite existing assistant command files"))
+        .stderr(contains("Run `mxw agent update` to refresh them."));
+}
+
+#[test]
+fn agent_update_refreshes_existing_command_files() {
+    let temp_dir = init_git_repo();
+
+    Command::cargo_bin("mxw")
+        .expect("binary")
+        .args(["agent", "install", "--tool", "cursor"])
+        .current_dir(temp_dir.path())
+        .assert()
+        .success();
+
+    let path = temp_dir.path().join(".cursor/commands/mxw/close.md");
+    fs::write(&path, "stale command").expect("overwrite command");
+
+    Command::cargo_bin("mxw")
+        .expect("binary")
+        .args(["agent", "update", "--tool", "cursor"])
+        .current_dir(temp_dir.path())
+        .assert()
+        .success()
+        .stdout(contains("Updated assistant slash commands."))
+        .stdout(contains("Updated: .cursor/commands/mxw/close.md"));
+
+    let rendered = fs::read_to_string(path).expect("read command");
+    assert!(rendered.contains("# /mxw:close"));
+    assert!(rendered.contains("status to `completed`"));
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -321,7 +321,9 @@ fn agent_install_refuses_to_overwrite_changed_command_files_without_update() {
         .current_dir(temp_dir.path())
         .assert()
         .failure()
-        .stderr(contains("Refusing to overwrite existing assistant command files"))
+        .stderr(contains(
+            "Refusing to overwrite existing assistant command files",
+        ))
         .stderr(contains("Run `mxw agent update` to refresh them."));
 }
 

--- a/workflow/workstreams/011-slash-command-integration/STATUS.md
+++ b/workflow/workstreams/011-slash-command-integration/STATUS.md
@@ -2,6 +2,31 @@
 status: completed
 summary: Shipped repo-local slash-command installation for Claude Code and Cursor with Mnemix-native commands, docs, and tests.
 updated: 2026-04-09
+prs:
+- 75
+github:
+  issue: null
+  parent_issue:
+    id: 4228561315
+    number: 76
+    url: https://github.com/micahcourey/mnemix-workflow/issues/76
+  sub_issues:
+    plan.md:
+      id: 4228561496
+      number: 79
+      url: https://github.com/micahcourey/mnemix-workflow/issues/79
+    spec.md:
+      id: 4228561368
+      number: 77
+      url: https://github.com/micahcourey/mnemix-workflow/issues/77
+    tasks.md:
+      id: 4228561568
+      number: 80
+      url: https://github.com/micahcourey/mnemix-workflow/issues/80
+    ux.md:
+      id: 4228561433
+      number: 78
+      url: https://github.com/micahcourey/mnemix-workflow/issues/78
 
 ---
 

--- a/workflow/workstreams/011-slash-command-integration/STATUS.md
+++ b/workflow/workstreams/011-slash-command-integration/STATUS.md
@@ -1,0 +1,12 @@
+---
+status: completed
+summary: Shipped repo-local slash-command installation for Claude Code and Cursor with Mnemix-native commands, docs, and tests.
+updated: 2026-04-09
+
+---
+
+# Status
+
+This workstream is complete. `mxw agent install`, `mxw agent update`, and
+`mxw agent tools` now ship repo-local slash-command support for Claude Code and
+Cursor using the namespaced Mnemix Workflow command set.

--- a/workflow/workstreams/011-slash-command-integration/decisions/README.md
+++ b/workflow/workstreams/011-slash-command-integration/decisions/README.md
@@ -1,0 +1,5 @@
+# Workstream Decisions
+
+This folder is for decisions local to `Slash Command Integration`.
+
+Promote decisions to `workflow/decisions/` when they become durable across future workstreams.

--- a/workflow/workstreams/011-slash-command-integration/plan.md
+++ b/workflow/workstreams/011-slash-command-integration/plan.md
@@ -1,0 +1,108 @@
+# Plan: Slash Command Integration
+
+## Summary
+
+Add an agent-integration layer that installs and refreshes tool-specific
+slash-command prompt files from shared repo templates while keeping `mxw` as
+the authoritative engine for tracked-work behavior. The first slice should ship
+the six approved commands, support a focused initial tool set, and document the
+feature clearly in both the README and dedicated slash-command docs.
+
+## Scope Analysis
+
+### Affected Areas
+
+| Area | Changes Required |
+|------|-----------------|
+| CLI commands | Add an install/update surface for assistant integrations and expose a clear supported-tools model |
+| Embedded resources | Add shared slash-command templates and any tool-adapter metadata needed to render them |
+| Packaging and file generation | Write repo-local or global command files into the paths required by supported assistants |
+| Documentation | Add slash-command reference docs and update the README, skill docs, and conventions where needed |
+| Tests | Cover command generation, file-path resolution, and user-facing CLI output for install/update flows |
+
+### Affected Layers
+
+- [x] Documentation
+- [x] Workflow artifacts
+- [ ] Scripts
+- [x] CLI implementation
+
+## Technical Design
+
+### Proposed Additions
+
+```text
+src/cli.rs
+src/commands/agent.rs
+src/commands/mod.rs
+src/agent/
+  commands.rs
+  render.rs
+  tools.rs
+resources/commands/
+  explore.md
+  track.md
+  implement.md
+  close.md
+  sync.md
+  status.md
+README.md
+docs/slash-commands.md
+resources/skills/mnemix-workflow/SKILL.md
+resources/skills/mnemix-workflow/references/workstream-conventions.md
+tests/cli.rs
+```
+
+### Design Constraints
+
+- Slash commands should remain a generated integration layer, not a second workflow engine
+- The product language is fixed for this slice: `explore`, `track`, `implement`, `close`, `sync`, and `status`
+- The implementation should start with a focused set of supported assistants rather than a long tail of partial integrations
+- Prompt templates should be shared and rendered into tool-specific file layouts, not hand-maintained per tool
+- `/mxw:sync` should preserve future tracker-provider flexibility while integrating with the tracker surface that exists today
+- README and docs should explain both install/update setup and daily usage examples
+
+## Implementation Slices
+
+### Slice 1
+
+- Decide the CLI surface for assistant integration management
+- Define the first supported-tool matrix and file-path rules
+- Define the shared prompt-template shape and any placeholder variables
+- Define the exact behavioral contract for each slash command
+- Decide how `/mxw:sync` maps to current GitHub behavior and future provider growth
+- Add a dedicated documentation outline so README and slash-command docs stay aligned
+
+### Slice 2
+
+- Implement the install/update command flow in the Rust CLI
+- Implement prompt rendering and tool-specific file generation
+- Add the six shared slash-command templates
+- Add support for the initial supported tools with deterministic output paths
+- Add tests for rendering, path selection, and CLI output
+
+### Slice 3
+
+- Write `docs/slash-commands.md` as the full command reference
+- Update `README.md` with setup, examples, and the slash-command value proposition
+- Update `resources/skills/mnemix-workflow/SKILL.md` to reference the new command surface where appropriate
+- Update conventions or methodology docs if slash commands change the recommended onboarding path
+- Validate the documentation against the shipped command names and install flow
+
+## Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+| Tool-specific path differences create edge cases | Medium | Medium | Start with a small supported-tool set and centralize path logic in one module |
+| Prompt templates drift from actual CLI behavior | High | Medium | Keep prompts thin, reuse shared language, and document that `mxw` remains authoritative |
+| `/mxw:sync` overpromises future tracker support | Medium | Medium | Document GitHub-first behavior clearly and frame future providers as additive |
+| README grows too large or duplicative | Low | Medium | Keep README concise and move deeper command details into `docs/slash-commands.md` |
+
+## References
+
+- `README.md`
+- `docs/prd.md`
+- `resources/skills/mnemix-workflow/SKILL.md`
+- `workflow/workstreams/009-github-issue-support/plan.md`
+- `workflow/workstreams/010-linear-issue-support/plan.md`
+- `https://github.com/Fission-AI/OpenSpec/blob/main/docs/commands.md`
+- `https://github.com/Fission-AI/OpenSpec/blob/main/docs/supported-tools.md`

--- a/workflow/workstreams/011-slash-command-integration/spec.md
+++ b/workflow/workstreams/011-slash-command-integration/spec.md
@@ -1,0 +1,102 @@
+# Feature Spec: Slash Command Integration
+
+## Summary
+
+Add opt-in slash-command support so `mnemix-workflow` can install tool-specific
+prompt files for supported AI coding assistants and expose a Mnemix-native
+command set in chat: `/mxw:explore`, `/mxw:track`, `/mxw:implement`,
+`/mxw:close`, `/mxw:sync`, and `/mxw:status`.
+
+## Problem
+
+`mnemix-workflow` already has a strong repo-native CLI and skill, but it still
+depends on users and agents remembering the explicit `mxw` command surface or
+loading the workflow skill manually. Competing workflow tools have made chat
+entrypoints feel more immediate by installing slash commands directly into the
+assistant environment. Without an equivalent layer, Mnemix Workflow is easier
+to adopt for maintainers who already know the CLI than for teams that want a
+chat-first operational path.
+
+## Users
+
+- Primary persona: maintainer or engineering lead who wants a chat-native way to use Mnemix Workflow in supported AI tools
+- Secondary persona: AI implementation agent that needs deterministic, repo-aligned command prompts instead of ad hoc chat instructions
+
+## Goals
+
+- Create a Mnemix-native slash-command vocabulary that reflects the product's tracked-work model rather than copying another tool's naming
+- Install and refresh tool-specific command files from shared templates
+- Keep the existing Rust CLI and workflow artifacts as the source of truth for behavior
+- Document the slash-command experience clearly in the README and dedicated docs so teams can adopt it without guessing
+
+## Non-Goals
+
+- Implement a generic runtime slash-command parser inside the Rust CLI
+- Copy OpenSpec's change and archive semantics into Mnemix Workflow
+- Support every AI coding tool in the first slice
+- Deliver bidirectional tracker editing or broad new tracker-provider work as part of this slice
+
+## User Value
+
+Teams get the convenience of chat-native workflow commands without giving up
+repo-native planning artifacts, explicit status metadata, or the existing
+`mxw` command model. The feature lowers adoption friction while preserving the
+product's actual methodology.
+
+## Functional Requirements
+
+- The product should ship a first-class slash-command set with these names:
+  `/mxw:explore`, `/mxw:track`, `/mxw:implement`, `/mxw:close`, `/mxw:sync`,
+  and `/mxw:status`
+- There should be an install/update workflow that writes tool-specific command
+  files for supported assistants from shared repo-owned templates
+- Slash-command templates should encode Mnemix Workflow behavior and naming,
+  not OpenSpec naming
+- `/mxw:track` should guide the agent toward the correct tracked unit
+  (workstream or patch) and the right artifact-creation flow
+- `/mxw:implement` should guide the agent to execute from tracked artifacts,
+  update task state, and validate work where appropriate
+- `/mxw:close` should reflect Mnemix Workflow's status model by marking tracked
+  work finished rather than assuming archive-folder semantics
+- `/mxw:status` should help the agent inspect or report the state of a
+  workstream or patch
+- `/mxw:sync` should be phrased as a tracker-sync command that works with
+  GitHub first and leaves room for future configured tracker providers
+- The implementation should support at least a small initial set of tools with
+  documented install paths and update behavior
+- The README and dedicated documentation should explain the command set,
+  supported tools, installation flow, and the relationship between slash
+  commands, the CLI, and the workflow skill
+
+## Constraints
+
+- The repo remains canonical; slash commands are an integration layer, not a new source of state
+- Existing `mxw` and `mnx` behavior should remain valid and should not become second-class
+- Command prompts need to work with tool-specific file layouts rather than assuming one universal slash-command format
+- The design should preserve room for future tracker-provider expansion behind `/mxw:sync`
+
+## Success Criteria
+
+- A maintainer can install slash-command support into supported AI tools from the repository workflow
+- Supported tools expose the six Mnemix-native commands with behavior aligned to the repo methodology
+- The generated command files are clearly derived from shared templates and can be refreshed on update
+- The README and dedicated slash-command docs make setup and day-to-day usage easy to understand
+- The feature strengthens adoption without forcing archive semantics or other product-language drift
+
+## Risks
+
+- Tool-specific prompt-file conventions may vary enough to make the integration layer broader than expected
+- Generic `/mxw:sync` language may get ahead of the currently shipped tracker-provider surface if the mapping is not documented carefully
+- If the slash-command prompts become too smart, they could drift from the real CLI behavior and create a maintenance burden
+- Naming is now intentionally Mnemix-specific, so weak documentation would make the command set feel arbitrary to new users
+
+## References
+
+- `README.md`
+- `docs/prd.md`
+- `resources/skills/mnemix-workflow/SKILL.md`
+- `resources/skills/mnemix-workflow/references/workstream-conventions.md`
+- `workflow/workstreams/009-github-issue-support/spec.md`
+- `workflow/workstreams/010-linear-issue-support/spec.md`
+- `https://github.com/Fission-AI/OpenSpec/blob/main/docs/commands.md`
+- `https://github.com/Fission-AI/OpenSpec/blob/main/docs/supported-tools.md`

--- a/workflow/workstreams/011-slash-command-integration/tasks.md
+++ b/workflow/workstreams/011-slash-command-integration/tasks.md
@@ -1,0 +1,43 @@
+# Tasks: Slash Command Integration
+
+## Workstream Goal
+
+Ship installable slash-command support that exposes a Mnemix-native chat
+command surface for supported AI tools and teaches it clearly through product
+documentation.
+
+## Execution Slices
+
+### Slice 1
+
+- [x] Finalize the assistant-integration CLI surface for installing and refreshing slash commands
+- [x] Finalize the initial supported-tool set and their command-file path rules
+- [x] Define the behavioral contract for `/mxw:explore`, `/mxw:track`, `/mxw:implement`, `/mxw:close`, `/mxw:sync`, and `/mxw:status`
+- [x] Define how `/mxw:sync` maps to current GitHub support and future tracker-provider growth
+
+### Slice 2
+
+- [x] Implement prompt-template rendering and tool-specific command-file generation
+- [x] Add shared template files for the six slash commands
+- [x] Implement the CLI install/update flow for the initial supported tools
+- [x] Add automated tests for rendering, output paths, and install/update CLI behavior
+
+### Slice 3
+
+- [x] Write `docs/slash-commands.md` with setup, supported tools, command reference, and examples
+- [x] Update `README.md` to introduce slash commands and link to the full command docs
+- [x] Update `resources/skills/mnemix-workflow/SKILL.md` to reflect the new chat-native entrypoint where appropriate
+- [x] Update any conventions or methodology docs that should mention slash-command setup
+- [x] Run validation and a documentation pass to confirm the command names and examples are consistent
+
+## Validation Checklist
+
+- [x] `cargo test`
+- [x] `cargo run --bin mxw -- --help`
+- [x] Exercise the install/update flow in a temporary tool-directory fixture
+- [x] Confirm README and docs use the same six command names and describe the same setup path
+
+## Notes
+
+- Keep product language aligned with the chosen Mnemix-native names rather than OpenSpec-compatible names
+- Treat slash commands as an integration convenience layer over the existing repo-native workflow model

--- a/workflow/workstreams/011-slash-command-integration/ux.md
+++ b/workflow/workstreams/011-slash-command-integration/ux.md
@@ -1,0 +1,138 @@
+# UX Spec: Slash Command Integration
+
+## Summary
+
+The slash-command experience should make `mnemix-workflow` feel immediately
+usable inside supported AI assistants. A maintainer should be able to install
+the commands once, tell the agent `/mxw:track` or `/mxw:implement`, and get a
+workflow-consistent result without remembering the underlying CLI details.
+
+## Users And Context
+
+- Primary persona: maintainer working inside a repository that uses or is adopting Mnemix Workflow
+- Context of use: chat with an AI coding assistant such as Codex, Claude Code, or Cursor while operating inside a local repo
+- Preconditions: the repository is initialized for Mnemix Workflow and the tool-specific slash-command files are installed or refreshed
+
+## User Goals
+
+- Start or continue tracked work from chat using names that match the Mnemix product language
+- Avoid memorizing the exact `mxw` subcommand graph for common tasks
+- Trust that slash commands still lead back to repo-native artifacts, status metadata, and validation behavior
+
+## Experience Principles
+
+- Mnemix-native language first: prefer names like `track` and `close` that fit the actual workflow model
+- Thin integration, real workflow: slash commands should guide or trigger the existing methodology rather than invent a parallel one
+- Low-friction setup: install and update flow should feel explicit but lightweight
+- Clear mental model: users should understand when the agent is exploring, creating tracked work, implementing, syncing, or reporting status
+
+## Primary Journey
+
+1. A maintainer installs or refreshes slash-command support for one or more AI tools from the repository.
+2. Inside a supported assistant, the maintainer invokes `/mxw:track` with a request for new work.
+3. The agent chooses the right tracked lane, creates or updates the relevant artifacts, and explains the next step in the workflow.
+4. Later, the maintainer uses `/mxw:implement`, `/mxw:status`, `/mxw:sync`, or `/mxw:close` to continue and finish the work.
+
+## Alternate Flows
+
+### Flow: Tool Not Yet Configured
+
+- Trigger: the user invokes a slash command in a tool that has not had Mnemix Workflow commands installed
+- Path: the command is unavailable, so the user follows the documented install flow and retries
+- Expected outcome: the recovery path is obvious from the docs and setup output
+
+### Flow: Repo Uses GitHub Today And Another Tracker Later
+
+- Trigger: the user invokes `/mxw:sync`
+- Path: the agent uses the configured tracker integration for the repository, starting with GitHub in the first shipped slice
+- Expected outcome: the command name stays stable even as the tracker-provider surface expands later
+
+## Surfaces
+
+### Surface: Installer Or Update Command Output
+
+- Purpose: confirm which tools were configured and where command files were written
+- Key information: selected tools, generated file paths, skipped tools, and update guidance
+- Available actions: install, refresh, inspect generated paths, and retry with a narrower tool set
+- Navigation expectations: output should be legible in a terminal and easy to paste into docs or issue comments
+
+### Surface: Generated Slash-Command Files
+
+- Purpose: give each supported assistant a native command entrypoint
+- Key information: command intent, when to use it, and the Mnemix Workflow behavior it should follow
+- Available actions: invoke `/mxw:explore`, `/mxw:track`, `/mxw:implement`, `/mxw:close`, `/mxw:sync`, and `/mxw:status`
+- Navigation expectations: file names and directory layout should match each tool's conventions cleanly
+
+### Surface: Documentation
+
+- Purpose: teach setup, naming, and the relation between slash commands, the CLI, and the workflow skill
+- Key information: supported tools, install/update flow, command reference, and examples
+- Available actions: follow setup, choose the right command, and understand product-language intent
+- Navigation expectations: README stays concise while dedicated docs carry the deeper command reference
+
+## States
+
+### Loading
+
+- Installer or update operations report progress per tool and do not leave the user guessing whether files were written
+
+### Empty
+
+- If no tools are selected or detected, the user gets a clear message and a path to install for a specific tool
+
+### Success
+
+- The user can invoke the slash commands immediately in the configured assistant and the docs reflect the same command set
+
+### Error
+
+- Unsupported tools, missing install locations, or write failures produce actionable errors with file-path context
+
+## Interaction Details
+
+- Command prompts should accept normal natural-language follow-up in chat rather than forcing rigid argument syntax
+- Install and update feedback should enumerate created or refreshed files
+- Generated commands should remain easy to invoke with standard slash-command completion in tools that support it
+- Global-path tools and repo-local-path tools should both be documented clearly so setup feels predictable
+
+## Content And Tone
+
+- Use explicit, instructional labels such as "Installed commands for Cursor" or "No supported tools selected"
+- Keep command descriptions calm and direct; the product should feel workflow-native rather than gimmicky
+- The docs should explain that slash commands are a convenience layer on top of repo-native workflow artifacts
+
+## Accessibility Requirements
+
+- Terminal setup output should remain plain-text and screen-reader friendly
+- Generated docs and command files should avoid unnecessary visual complexity
+- Naming should stay short and distinct enough for keyboard command pickers and autocomplete lists
+
+## Acceptance Scenarios
+
+```gherkin
+Scenario: Install slash commands for a supported tool
+  Given a repository that uses Mnemix Workflow
+  And a maintainer wants chat-native workflow commands in a supported assistant
+  When they run the slash-command install flow
+  Then tool-specific command files are written from shared templates
+  And the setup output explains which commands are now available
+
+Scenario: Track work from chat using Mnemix-native language
+  Given slash commands are installed
+  When the maintainer invokes /mxw:track in a supported assistant
+  Then the agent chooses the correct tracked lane for the requested work
+  And the result aligns with repo-native workstream or patch conventions
+
+Scenario: Close tracked work without archive-language drift
+  Given a tracked item is ready to finish
+  When the maintainer invokes /mxw:close
+  Then the agent updates the tracked work using Mnemix Workflow's status model
+  And the experience does not assume archive-folder semantics
+```
+
+## References
+
+- `README.md`
+- `resources/skills/mnemix-workflow/SKILL.md`
+- `workflow/workstreams/005-interactive-tui-mode/ux.md`
+- `https://github.com/Fission-AI/OpenSpec/blob/main/docs/commands.md`


### PR DESCRIPTION
## Summary
- add mxw agent install, update, and tools for repo-local assistant command generation
- ship the Mnemix-native /mxw slash-command templates for Claude Code and Cursor
- document the feature in the README, slash-command docs, and workflow skill references

## Validation
- cargo test
- cargo run --bin mxw -- validate
- cargo run --bin mxw -- --help
- cargo run --bin mxw -- validate 011
- cargo run --bin mxw -- status set 011 completed --summary "Shipped repo-local slash-command installation for Claude Code and Cursor with Mnemix-native commands, docs, and tests."
- cargo run --bin mxw -- agent install --tool claude --tool cursor (in a temporary git repo fixture)
